### PR TITLE
feat: add Claude Skills templates for core module guardrails

### DIFF
--- a/.claude/skills/sdk-behavior-extension-design.md
+++ b/.claude/skills/sdk-behavior-extension-design.md
@@ -1,0 +1,737 @@
+# SDK Extension Design: Behavior Intelligence for mem-intel-sdk v2.0
+
+## Overview
+
+This document outlines the extension of `@lanonasis/mem-intel-sdk` to support behavioral pattern learning - the "golden flavor" that records user workflows and replays them in future sessions.
+
+## Design Principles
+
+1. **Local-First** - Use cached embeddings for pattern matching, API as fallback
+2. **Non-Breaking** - All new features are additive, existing API unchanged
+3. **Same Backend** - Leverage existing Supabase tables + minimal schema additions
+4. **Minimal Footprint** - No new dependencies beyond what exists
+
+## Current SDK Structure
+
+```
+@lanonasis/mem-intel-sdk/
+├── dist/
+│   ├── core/
+│   │   ├── client.js          # MemoryIntelligenceClient
+│   │   ├── types.js           # TypeScript definitions
+│   │   └── errors.js          # Error classes
+│   ├── server/
+│   │   └── index.js           # MCP Server (createMCPServer)
+│   ├── utils/
+│   │   ├── similarity.js      # cosineSimilarity()
+│   │   ├── embeddings.js      # Embedding utilities
+│   │   ├── http-client.js     # HttpClient with cache
+│   │   └── response-adapter.js # ResponseCache
+│   ├── react/                 # React hooks
+│   ├── vue/                   # Vue composables
+│   └── node/                  # Node.js entry
+```
+
+## Proposed Extensions
+
+### 1. New Types (`core/types.ts`)
+
+```typescript
+// Add to existing types
+
+export type BehaviorOutcome = 'success' | 'partial' | 'failed';
+
+export interface ToolAction {
+  tool: string;
+  parameters: Record<string, any>;
+  outcome: BehaviorOutcome;
+  timestamp: string;
+  duration_ms?: number;
+}
+
+export interface WorkflowPattern {
+  id: string;
+  user_id: string;
+  trigger: string;
+  trigger_embedding?: number[];
+  context: {
+    directory: string;
+    project_type?: string;
+    branch?: string;
+    files_touched?: string[];
+  };
+  actions: ToolAction[];
+  final_outcome: BehaviorOutcome;
+  confidence: number;
+  use_count: number;
+  last_used_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BehaviorRecordParams {
+  userId: string;
+  trigger: string;
+  context: {
+    directory: string;
+    projectType?: string;
+    branch?: string;
+    filesTouched?: string[];
+  };
+  actions: ToolAction[];
+  finalOutcome: BehaviorOutcome;
+  confidence?: number;
+}
+
+export interface BehaviorRecallParams {
+  userId: string;
+  context: {
+    currentDirectory: string;
+    currentTask: string;
+    projectType?: string;
+  };
+  limit?: number;
+  similarityThreshold?: number;
+}
+
+export interface BehaviorSuggestParams {
+  userId: string;
+  currentState: {
+    taskDescription: string;
+    completedSteps: string[];
+    currentFiles?: string[];
+  };
+  maxSuggestions?: number;
+}
+
+export interface BehaviorRecallResult {
+  patterns: Array<{
+    pattern: WorkflowPattern;
+    similarity_score: number;
+    relevance_reason: string;
+  }>;
+  total_found: number;
+}
+
+export interface BehaviorSuggestion {
+  action: string;
+  tool: string;
+  confidence: number;
+  based_on_patterns: string[];
+  reasoning: string;
+}
+```
+
+### 2. Client Extension (`core/client.ts`)
+
+```typescript
+// Add to MemoryIntelligenceClient class
+
+/**
+ * Record a successful workflow pattern for future recall
+ */
+async recordBehavior(params: BehaviorRecordParams): Promise<{
+  data: WorkflowPattern;
+  usage?: UsageInfo;
+}> {
+  // First check for duplicates locally
+  if (this.processingMode === 'offline-fallback' && this.cache) {
+    const existing = await this.findSimilarBehavior(params.trigger, params.userId);
+    if (existing && existing.similarity > 0.95) {
+      // Update use_count instead of creating duplicate
+      return this.updateBehaviorUsage(existing.id);
+    }
+  }
+
+  const response = await this.httpClient.postEnhanced(
+    '/intelligence/behavior/record',
+    {
+      user_id: params.userId,
+      trigger: params.trigger,
+      context: params.context,
+      actions: params.actions,
+      final_outcome: params.finalOutcome,
+      confidence: params.confidence || 0.7
+    }
+  );
+
+  if (response.error) {
+    throw new DatabaseError(`Failed to record behavior: ${response.error.message}`);
+  }
+
+  return {
+    data: response.data,
+    usage: response.usage
+  };
+}
+
+/**
+ * Recall relevant behavior patterns for current context
+ * Uses local-first approach with cached embeddings
+ */
+async recallBehavior(params: BehaviorRecallParams): Promise<{
+  data: BehaviorRecallResult;
+  usage?: UsageInfo;
+  fromCache?: boolean;
+}> {
+  // Try local cache first
+  if (this.processingMode === 'offline-fallback' && this.cache) {
+    const cached = await this.localBehaviorSearch(params);
+    if (cached.patterns.length > 0) {
+      return { data: cached, fromCache: true };
+    }
+  }
+
+  const response = await this.httpClient.postEnhanced(
+    '/intelligence/behavior/recall',
+    {
+      user_id: params.userId,
+      context: params.context,
+      limit: params.limit || 5,
+      similarity_threshold: params.similarityThreshold || 0.7
+    }
+  );
+
+  if (response.error) {
+    throw new DatabaseError(`Failed to recall behavior: ${response.error.message}`);
+  }
+
+  // Cache for future local queries
+  if (this.cache && response.data) {
+    this.cacheBehaviorPatterns(response.data.patterns);
+  }
+
+  return {
+    data: response.data,
+    usage: response.usage,
+    fromCache: false
+  };
+}
+
+/**
+ * Get AI-powered suggestions for next actions
+ */
+async suggestBehavior(params: BehaviorSuggestParams): Promise<{
+  data: { suggestions: BehaviorSuggestion[] };
+  usage?: UsageInfo;
+}> {
+  const response = await this.httpClient.postEnhanced(
+    '/intelligence/behavior/suggest',
+    {
+      user_id: params.userId,
+      current_state: params.currentState,
+      max_suggestions: params.maxSuggestions || 3
+    }
+  );
+
+  if (response.error) {
+    throw new DatabaseError(`Failed to suggest behavior: ${response.error.message}`);
+  }
+
+  return {
+    data: response.data,
+    usage: response.usage
+  };
+}
+
+// Private helper methods
+
+private async localBehaviorSearch(params: BehaviorRecallParams): Promise<BehaviorRecallResult> {
+  const cachedPatterns = this.cache?.get('behavior_patterns') || [];
+
+  // Filter by context
+  const contextMatches = cachedPatterns.filter((p: WorkflowPattern) => {
+    if (params.context.projectType && p.context.project_type !== params.context.projectType) {
+      return false;
+    }
+    return true;
+  });
+
+  // Semantic search on trigger text (using cached embeddings)
+  const taskEmbedding = await this.getEmbedding(params.context.currentTask);
+  const scored = contextMatches.map((p: WorkflowPattern) => ({
+    pattern: p,
+    similarity_score: cosineSimilarity(taskEmbedding, p.trigger_embedding || []),
+    relevance_reason: `Matched trigger: "${p.trigger.substring(0, 50)}..."`
+  }));
+
+  // Filter by threshold and sort
+  const filtered = scored
+    .filter(s => s.similarity_score >= (params.similarityThreshold || 0.7))
+    .sort((a, b) => b.similarity_score - a.similarity_score)
+    .slice(0, params.limit || 5);
+
+  return {
+    patterns: filtered,
+    total_found: filtered.length
+  };
+}
+
+private cacheBehaviorPatterns(patterns: WorkflowPattern[]): void {
+  const existing = this.cache?.get('behavior_patterns') || [];
+  const merged = [...existing];
+
+  for (const p of patterns) {
+    const idx = merged.findIndex(e => e.id === p.id);
+    if (idx >= 0) {
+      merged[idx] = p;
+    } else {
+      merged.push(p);
+    }
+  }
+
+  this.cache?.set('behavior_patterns', merged);
+}
+```
+
+### 3. MCP Server Extension (`server/mcp-server.ts`)
+
+```typescript
+// Add to createMCPServer function
+
+server.registerTool(
+  'behavior_record',
+  {
+    title: 'Record Behavior Pattern',
+    description: 'Record a successful workflow pattern for future recall and learning.',
+    inputSchema: z.object({
+      user_id: z.string().uuid(),
+      trigger: z.string().min(10).max(500),
+      context: z.object({
+        directory: z.string(),
+        project_type: z.string().optional(),
+        branch: z.string().optional(),
+        files_touched: z.array(z.string()).optional()
+      }),
+      actions: z.array(z.object({
+        tool: z.string(),
+        parameters: z.record(z.any()),
+        outcome: z.enum(['success', 'partial', 'failed']),
+        timestamp: z.string().datetime(),
+        duration_ms: z.number().optional()
+      })),
+      final_outcome: z.enum(['success', 'partial', 'failed']),
+      confidence: z.number().min(0).max(1).default(0.7)
+    }).strict(),
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true
+    }
+  },
+  async (rawParams) => {
+    try {
+      const response = await client.recordBehavior({
+        userId: rawParams.user_id,
+        trigger: rawParams.trigger,
+        context: rawParams.context,
+        actions: rawParams.actions,
+        finalOutcome: rawParams.final_outcome,
+        confidence: rawParams.confidence
+      });
+
+      return {
+        content: [{
+          type: 'text',
+          text: `Behavior pattern recorded successfully.\nPattern ID: ${response.data.id}\nConfidence: ${response.data.confidence}`
+        }]
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [{
+          type: 'text',
+          text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
+        }]
+      };
+    }
+  }
+);
+
+server.registerTool(
+  'behavior_recall',
+  {
+    title: 'Recall Behavior Patterns',
+    description: 'Recall relevant behavior patterns for the current task context.',
+    inputSchema: z.object({
+      user_id: z.string().uuid(),
+      context: z.object({
+        current_directory: z.string(),
+        current_task: z.string(),
+        project_type: z.string().optional()
+      }),
+      limit: z.number().int().min(1).max(10).default(5),
+      similarity_threshold: z.number().min(0).max(1).default(0.7),
+      response_format: z.enum(['json', 'markdown']).default('markdown')
+    }).strict(),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true
+    }
+  },
+  async (rawParams) => {
+    try {
+      const response = await client.recallBehavior({
+        userId: rawParams.user_id,
+        context: {
+          currentDirectory: rawParams.context.current_directory,
+          currentTask: rawParams.context.current_task,
+          projectType: rawParams.context.project_type
+        },
+        limit: rawParams.limit,
+        similarityThreshold: rawParams.similarity_threshold
+      });
+
+      const result = response.data;
+      const responseText = formatResponse(
+        result,
+        rawParams.response_format,
+        (data) => {
+          let md = `# Relevant Behavior Patterns\n\n`;
+          md += `**Task:** ${rawParams.context.current_task}\n`;
+          md += `**Found:** ${data.total_found} patterns\n`;
+          md += `**Source:** ${response.fromCache ? 'Local Cache' : 'API'}\n\n`;
+
+          for (const { pattern, similarity_score, relevance_reason } of data.patterns) {
+            md += `## ${pattern.trigger.substring(0, 60)}...\n`;
+            md += `**Similarity:** ${(similarity_score * 100).toFixed(1)}%\n`;
+            md += `**Confidence:** ${(pattern.confidence * 100).toFixed(0)}%\n`;
+            md += `**Used:** ${pattern.use_count} times\n\n`;
+            md += `**Action Chain:**\n`;
+            for (const action of pattern.actions) {
+              md += `- \`${action.tool}\` → ${action.outcome}\n`;
+            }
+            md += `\n`;
+          }
+
+          return md;
+        }
+      );
+
+      return {
+        content: [{ type: 'text', text: truncateIfNeeded(responseText) }]
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [{
+          type: 'text',
+          text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
+        }]
+      };
+    }
+  }
+);
+
+server.registerTool(
+  'behavior_suggest',
+  {
+    title: 'Suggest Next Actions',
+    description: 'Get AI-powered suggestions for next actions based on learned patterns.',
+    inputSchema: z.object({
+      user_id: z.string().uuid(),
+      current_state: z.object({
+        task_description: z.string(),
+        completed_steps: z.array(z.string()),
+        current_files: z.array(z.string()).optional()
+      }),
+      max_suggestions: z.number().int().min(1).max(5).default(3),
+      response_format: z.enum(['json', 'markdown']).default('markdown')
+    }).strict(),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true
+    }
+  },
+  async (rawParams) => {
+    try {
+      const response = await client.suggestBehavior({
+        userId: rawParams.user_id,
+        currentState: {
+          taskDescription: rawParams.current_state.task_description,
+          completedSteps: rawParams.current_state.completed_steps,
+          currentFiles: rawParams.current_state.current_files
+        },
+        maxSuggestions: rawParams.max_suggestions
+      });
+
+      const result = response.data;
+      const responseText = formatResponse(
+        result,
+        rawParams.response_format,
+        (data) => {
+          let md = `# Suggested Next Actions\n\n`;
+
+          for (const suggestion of data.suggestions) {
+            md += `## ${suggestion.action}\n`;
+            md += `**Tool:** \`${suggestion.tool}\`\n`;
+            md += `**Confidence:** ${(suggestion.confidence * 100).toFixed(0)}%\n`;
+            md += `**Reasoning:** ${suggestion.reasoning}\n\n`;
+          }
+
+          return md;
+        }
+      );
+
+      return {
+        content: [{ type: 'text', text: truncateIfNeeded(responseText) }]
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [{
+          type: 'text',
+          text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
+        }]
+      };
+    }
+  }
+);
+```
+
+### 4. Database Schema Extension (Supabase Migration)
+
+```sql
+-- Migration: Add behavior_patterns table
+-- Version: 2.0.0
+
+-- Behavior patterns table for workflow learning
+CREATE TABLE IF NOT EXISTS public.behavior_patterns (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Trigger (what initiated this workflow)
+  trigger TEXT NOT NULL,
+  trigger_embedding VECTOR(1536),  -- For semantic search
+
+  -- Context
+  context JSONB NOT NULL DEFAULT '{}',
+  -- Expected: { directory, project_type, branch, files_touched }
+
+  -- Action chain
+  actions JSONB NOT NULL DEFAULT '[]',
+  -- Expected: [{ tool, parameters, outcome, timestamp, duration_ms }]
+
+  -- Outcome
+  final_outcome TEXT NOT NULL CHECK (final_outcome IN ('success', 'partial', 'failed')),
+
+  -- Quality metrics
+  confidence FLOAT NOT NULL DEFAULT 0.7 CHECK (confidence >= 0 AND confidence <= 1),
+  use_count INT NOT NULL DEFAULT 1,
+  last_used_at TIMESTAMPTZ,
+
+  -- Timestamps
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for efficient querying
+CREATE INDEX behavior_patterns_user_id_idx ON public.behavior_patterns(user_id);
+CREATE INDEX behavior_patterns_final_outcome_idx ON public.behavior_patterns(final_outcome);
+CREATE INDEX behavior_patterns_confidence_idx ON public.behavior_patterns(confidence DESC);
+CREATE INDEX behavior_patterns_use_count_idx ON public.behavior_patterns(use_count DESC);
+
+-- Vector similarity index for semantic search
+CREATE INDEX behavior_patterns_embedding_idx
+  ON public.behavior_patterns
+  USING ivfflat (trigger_embedding vector_cosine_ops)
+  WITH (lists = 100);
+
+-- GIN index for JSONB context queries
+CREATE INDEX behavior_patterns_context_idx ON public.behavior_patterns USING GIN (context);
+
+-- RLS policies
+ALTER TABLE public.behavior_patterns ENABLE ROW LEVEL SECURITY;
+
+-- Users can only access their own patterns
+CREATE POLICY "Users can view own patterns" ON public.behavior_patterns
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own patterns" ON public.behavior_patterns
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own patterns" ON public.behavior_patterns
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own patterns" ON public.behavior_patterns
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- Function to auto-update updated_at
+CREATE OR REPLACE FUNCTION update_behavior_pattern_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER behavior_patterns_updated_at
+  BEFORE UPDATE ON public.behavior_patterns
+  FOR EACH ROW
+  EXECUTE FUNCTION update_behavior_pattern_timestamp();
+
+-- Function to increment use_count on recall
+CREATE OR REPLACE FUNCTION increment_pattern_use_count(pattern_id UUID)
+RETURNS void AS $$
+BEGIN
+  UPDATE public.behavior_patterns
+  SET use_count = use_count + 1,
+      last_used_at = NOW()
+  WHERE id = pattern_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+```
+
+### 5. API Routes (Edge Functions)
+
+```typescript
+// supabase/functions/intelligence-behavior-record/index.ts
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+serve(async (req) => {
+  const { user_id, trigger, context, actions, final_outcome, confidence } = await req.json();
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  );
+
+  // Generate embedding for trigger
+  const embeddingResponse = await fetch('https://api.openai.com/v1/embeddings', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${Deno.env.get('OPENAI_API_KEY')}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: 'text-embedding-3-small',
+      input: trigger
+    })
+  });
+
+  const { data: embeddingData } = await embeddingResponse.json();
+  const trigger_embedding = embeddingData[0].embedding;
+
+  // Check for near-duplicate
+  const { data: duplicates } = await supabase.rpc('find_similar_patterns', {
+    query_embedding: trigger_embedding,
+    match_threshold: 0.95,
+    match_count: 1,
+    p_user_id: user_id
+  });
+
+  if (duplicates?.length > 0) {
+    // Update existing pattern
+    await supabase.rpc('increment_pattern_use_count', { pattern_id: duplicates[0].id });
+    return new Response(JSON.stringify({
+      success: true,
+      data: duplicates[0],
+      message: 'Updated existing pattern'
+    }));
+  }
+
+  // Insert new pattern
+  const { data, error } = await supabase
+    .from('behavior_patterns')
+    .insert({
+      user_id,
+      trigger,
+      trigger_embedding,
+      context,
+      actions,
+      final_outcome,
+      confidence: confidence || 0.7
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return new Response(JSON.stringify({
+      success: false,
+      error: { message: error.message }
+    }), { status: 400 });
+  }
+
+  return new Response(JSON.stringify({
+    success: true,
+    data
+  }));
+});
+```
+
+## Version Bump
+
+```json
+{
+  "name": "@lanonasis/mem-intel-sdk",
+  "version": "2.0.0",
+  "description": "AI-powered memory and behavior intelligence SDK for LanOnasis Memory-as-a-Service",
+  "keywords": [
+    "memory",
+    "intelligence",
+    "behavior",
+    "workflow",
+    "patterns",
+    "ai",
+    "lanonasis",
+    "maas",
+    "memory-as-a-service",
+    "sdk"
+  ]
+}
+```
+
+## Migration Path
+
+### For Existing Users
+
+```typescript
+// v1.x - No changes needed, existing methods unchanged
+const client = new MemoryIntelligenceClient({ apiKey: 'lano_xxx' });
+await client.analyzePatterns({ userId, timeRangeDays: 30 });
+
+// v2.0 - New behavior methods available
+await client.recordBehavior({ userId, trigger, context, actions, finalOutcome });
+await client.recallBehavior({ userId, context });
+await client.suggestBehavior({ userId, currentState });
+```
+
+### For MCP Server Users
+
+```typescript
+// v1.x MCP tools still work
+// memory_analyze_patterns
+// memory_find_related
+// memory_extract_insights
+// etc.
+
+// v2.0 adds new tools
+// behavior_record
+// behavior_recall
+// behavior_suggest
+```
+
+## Testing Plan
+
+1. **Unit Tests** - Test each new method in isolation
+2. **Integration Tests** - Test end-to-end flow
+3. **Cache Tests** - Verify offline-fallback behavior
+4. **Performance Tests** - Measure semantic search latency
+
+## Release Checklist
+
+- [ ] Add new types to `core/types.ts`
+- [ ] Implement client methods in `core/client.ts`
+- [ ] Register MCP tools in `server/mcp-server.ts`
+- [ ] Run Supabase migration
+- [ ] Deploy edge functions
+- [ ] Update documentation
+- [ ] Bump version to 2.0.0
+- [ ] Publish to npm

--- a/.claude/skills/skill-base-client.md
+++ b/.claude/skills/skill-base-client.md
@@ -1,0 +1,200 @@
+# Skill: Base Client Guardian
+
+## Purpose & Scope
+
+This skill applies when modifying the **Universal API Client** (`core/base-client.js`).
+
+The Base Client provides:
+- HTTP request handling with axios
+- Multi-protocol authentication (Bearer, API Key, Basic, HMAC, OAuth2)
+- Exponential backoff retry logic
+- Circuit breaker pattern for fault tolerance
+- Rate limiting management
+- EventEmitter-based request/response/error logging
+
+## Critical Rules - NEVER Do
+
+### Public Method Stability
+- **NEVER** remove or rename these public methods:
+  - `request()` - Main entry point for API calls
+  - `retryRequest()` - Handles retry logic with backoff
+  - `healthCheck()` - Service health verification
+  - `generateMethods()` - Dynamic method generation from endpoints
+  - `addAuthentication()` - Auth injection into requests
+
+### EventEmitter Events
+- **NEVER** remove or rename these event names:
+  - `request` - Emitted before each request
+  - `response` - Emitted on successful response
+  - `error` - Emitted on request failure
+  - `circuit-breaker-open` - Emitted when circuit opens
+
+### Authentication Types
+- **NEVER** change these auth type identifiers:
+  - `bearer` - Bearer token auth
+  - `apikey` - API key (header or query)
+  - `basic` - Basic auth
+  - `hmac` - HMAC signature auth
+  - `oauth2` - OAuth 2.0 auth
+
+### Security
+- **NEVER** log sensitive data (auth tokens, credentials, API keys)
+- **NEVER** disable TLS/SSL verification
+- **NEVER** expose raw credentials in error messages
+- **NEVER** store credentials in plain text
+
+### Circuit Breaker
+- **NEVER** change the state machine flow: `CLOSED -> OPEN -> HALF_OPEN -> CLOSED`
+- **NEVER** remove the 5-failure threshold for circuit opening
+- **NEVER** remove the 60-second recovery timeout
+
+## Required Patterns - MUST Follow
+
+### Retry Logic
+```javascript
+// MUST use exponential backoff
+const delay = this.config.retryDelay * Math.pow(2, attempt - 1);
+
+// MUST check shouldRetry() before retrying
+if (attempt < this.config.retryAttempts && this.shouldRetry(error)) {
+    await this.sleep(delay);
+    return this.retryRequest(config, attempt + 1);
+}
+```
+
+### Event Emission
+```javascript
+// MUST emit events after state changes
+this.emit('request', { service, method, url, timestamp });
+this.emit('response', { service, status, statusText, timestamp });
+this.emit('error', { service, type, message, status, timestamp });
+```
+
+### Circuit Breaker State Management
+```javascript
+// MUST follow state machine
+// On success: reset to CLOSED
+this.circuitBreaker.failures = 0;
+this.circuitBreaker.state = 'CLOSED';
+
+// On failure: increment and potentially open
+this.circuitBreaker.failures++;
+if (this.circuitBreaker.failures >= 5) {
+    this.circuitBreaker.state = 'OPEN';
+    this.emit('circuit-breaker-open', { service, failures });
+}
+
+// On timeout: transition to HALF_OPEN
+if (timeSinceLastFailure > 60000) {
+    this.circuitBreaker.state = 'HALF_OPEN';
+}
+```
+
+### Authentication Handling
+```javascript
+// MUST handle all auth types in switch statement
+switch (auth.type) {
+    case 'bearer':
+    case 'apikey':
+    case 'basic':
+    case 'hmac':
+    case 'oauth2':
+        // Implementation here
+        break;
+}
+```
+
+## Safe Modification Examples
+
+### Adding a New Authentication Type
+```javascript
+// Add to the switch statement in addAuthentication()
+case 'custom_auth_type':
+    config.headers['X-Custom-Auth'] = auth.config.customValue;
+    break;
+```
+
+### Adding New Retry Conditions
+```javascript
+// Extend shouldRetry() - do NOT replace existing conditions
+shouldRetry(error) {
+    return (
+        error.code === 'ECONNRESET' ||
+        error.code === 'ETIMEDOUT' ||
+        error.code === 'ENOTFOUND' ||
+        error.code === 'YOUR_NEW_CODE' ||  // ADD here
+        (error.response && error.response.status >= 500)
+    );
+}
+```
+
+### Adding New Events
+```javascript
+// Add new events - do NOT modify existing event signatures
+this.emit('your-new-event', { service, customData, timestamp });
+```
+
+## Integration Points
+
+| Component | Integration Method |
+|-----------|-------------------|
+| Metrics Collector | Listen to `request`, `response`, `error` events |
+| Compliance Manager | Intercept in `addAuthentication()` |
+| Version Manager | Pass version in request options |
+| Vendor Abstraction | Uses `request()` method |
+
+## Testing Requirements
+
+Before any changes to this file:
+
+```bash
+# 1. Run existing tests
+npm test -- --grep "BaseClient"
+
+# 2. Verify authentication works for all types
+node -e "
+const BaseClient = require('./core/base-client');
+const client = new BaseClient({ name: 'test', baseUrl: 'https://httpbin.org' });
+console.log('Client initialized:', client.config.name);
+"
+
+# 3. Test circuit breaker states
+# Verify: CLOSED -> OPEN (after 5 failures) -> HALF_OPEN (after 60s)
+
+# 4. Test retry logic
+# Verify exponential backoff: delay * 2^(attempt-1)
+```
+
+## Rollback Procedure
+
+If changes cause issues:
+
+1. **Immediate Rollback**
+   ```bash
+   git checkout HEAD~1 -- core/base-client.js
+   ```
+
+2. **Verify Recovery**
+   ```bash
+   # Restart the server
+   bun run dev
+
+   # Check health endpoint
+   curl http://localhost:3001/health
+   ```
+
+3. **Event Listener Check**
+   ```javascript
+   // Verify all components can still receive events
+   client.on('request', () => console.log('Request event works'));
+   client.on('response', () => console.log('Response event works'));
+   client.on('error', () => console.log('Error event works'));
+   ```
+
+## Version History
+
+| Version | Changes |
+|---------|---------|
+| 1.0.0 | Initial implementation with 5 auth types |
+| 1.1.0 | Added circuit breaker pattern |
+| 1.2.0 | Added rate limiting support |

--- a/.claude/skills/skill-behavior-memory.md
+++ b/.claude/skills/skill-behavior-memory.md
@@ -1,0 +1,416 @@
+# Skill: Behavior Memory Integration
+
+## Purpose & Scope
+
+This skill teaches AI agents to leverage `@lanonasis/mem-intel-sdk` for **behavioral pattern learning** - recording successful workflows and recalling them in future sessions.
+
+**Key Principle**: Local-first processing with cached embeddings. API calls are fallback, not primary.
+
+## Architecture Understanding
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                 BEHAVIOR MEMORY FLOW                            │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  SESSION START                                                  │
+│  ┌─────────────────┐                                           │
+│  │ 1. Recall       │──► Query cached patterns for context      │
+│  │    Patterns     │──► Semantic match: current task → history │
+│  └─────────────────┘                                           │
+│           │                                                     │
+│           ▼                                                     │
+│  ┌─────────────────┐                                           │
+│  │ 2. Inject       │──► Enrich agent context with patterns     │
+│  │    Context      │──► "User typically does X when Y"         │
+│  └─────────────────┘                                           │
+│           │                                                     │
+│           ▼                                                     │
+│  SESSION EXECUTION                                              │
+│  ┌─────────────────┐                                           │
+│  │ 3. Agent        │──► Execute with pattern-informed behavior │
+│  │    Actions      │──► Track tools used, outcomes             │
+│  └─────────────────┘                                           │
+│           │                                                     │
+│           ▼                                                     │
+│  SESSION END                                                    │
+│  ┌─────────────────┐                                           │
+│  │ 4. Record       │──► Store: trigger → actions → outcome     │
+│  │    Pattern      │──► Generate embedding for future recall   │
+│  └─────────────────┘                                           │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Memory Types for Behavior Patterns
+
+Use the correct `MemoryType` when storing behavior patterns:
+
+| Memory Type | Use For |
+|-------------|---------|
+| `workflow` | Multi-step action sequences |
+| `context` | Session context (directory, project type) |
+| `project` | Project-specific patterns |
+| `knowledge` | Learned preferences and rules |
+| `personal` | User-specific behavior preferences |
+
+## MCP Tools Available
+
+### Analysis Tools (Read-Only)
+
+```typescript
+// Analyze user's behavior patterns over time
+memory_analyze_patterns({
+  user_id: "uuid",
+  time_range_days: 30,
+  response_format: "markdown"
+})
+// Returns: peak hours, memory types distribution, trends
+
+// Find related memories using vector similarity
+memory_find_related({
+  memory_id: "uuid",
+  user_id: "uuid",
+  limit: 10,
+  similarity_threshold: 0.7
+})
+// Returns: semantically similar memories
+
+// Extract insights from memories
+memory_extract_insights({
+  user_id: "uuid",
+  topic: "deployment",        // Optional filter
+  memory_type: "workflow",    // Optional filter
+  max_memories: 20
+})
+// Returns: patterns, learnings, opportunities, risks
+```
+
+### Suggestion Tools
+
+```typescript
+// Get AI-powered tag suggestions
+memory_suggest_tags({
+  memory_id: "uuid",
+  user_id: "uuid",
+  max_suggestions: 5
+})
+// Returns: suggested tags with confidence scores
+
+// Detect duplicate memories
+memory_detect_duplicates({
+  user_id: "uuid",
+  similarity_threshold: 0.9
+})
+// Returns: duplicate pairs with recommendations
+```
+
+### Health Monitoring
+
+```typescript
+// Check memory organization quality
+memory_health_check({
+  user_id: "uuid"
+})
+// Returns: health score, metrics, issues, recommendations
+```
+
+## Session Integration Patterns
+
+### Pattern 1: Session Start - Recall & Inject
+
+```javascript
+// On session start, recall relevant patterns
+async function onSessionStart(context) {
+  const client = new MemoryIntelligenceClient({
+    apiKey: process.env.LANONASIS_API_KEY,
+    processingMode: 'offline-fallback',  // Local-first!
+    enableCache: true
+  });
+
+  // Extract insights relevant to current task
+  const insights = await client.extractInsights({
+    userId: context.userId,
+    topic: context.currentTask,
+    memoryType: 'workflow',
+    maxMemories: 10
+  });
+
+  // Inject into agent context
+  return {
+    systemPromptAddition: `
+## User Behavior Patterns
+${insights.data.summary}
+
+## Relevant Past Actions
+${insights.data.insights
+  .filter(i => i.category === 'pattern')
+  .map(i => `- ${i.title}: ${i.description}`)
+  .join('\n')}
+`
+  };
+}
+```
+
+### Pattern 2: Session End - Record Successful Pattern
+
+```javascript
+// On successful session end, record the pattern
+async function onSessionEnd(context, outcome) {
+  if (outcome.status !== 'success') return;
+
+  const client = new MemoryIntelligenceClient({
+    apiKey: process.env.LANONASIS_API_KEY
+  });
+
+  // Store as workflow memory for future recall
+  await client.httpClient.post('/memories', {
+    user_id: context.userId,
+    title: `Workflow: ${context.taskSummary}`,
+    content: JSON.stringify({
+      trigger: context.initialPrompt,
+      actions: context.toolsUsed,
+      outcome: outcome.result,
+      duration: outcome.duration
+    }),
+    type: 'workflow',
+    tags: extractTags(context),
+    metadata: {
+      directory: context.workingDirectory,
+      project_type: context.projectType,
+      confidence: outcome.userSatisfaction || 0.7
+    }
+  });
+}
+```
+
+### Pattern 3: Real-Time Pattern Matching
+
+```javascript
+// During execution, match current action to past patterns
+async function matchPattern(currentAction) {
+  const client = new MemoryIntelligenceClient({
+    apiKey: process.env.LANONASIS_API_KEY,
+    processingMode: 'offline-fallback'
+  });
+
+  // Find related workflows
+  const related = await client.findRelated({
+    memoryId: currentAction.contextMemoryId,
+    userId: currentAction.userId,
+    limit: 5,
+    similarityThreshold: 0.75
+  });
+
+  // Return matching patterns for guidance
+  return related.data.related_memories.map(m => ({
+    pattern: JSON.parse(m.content_preview),
+    similarity: m.similarity_score
+  }));
+}
+```
+
+## Critical Rules - NEVER Do
+
+### Data Privacy
+- **NEVER** store PII in behavior patterns
+- **NEVER** record authentication tokens or secrets
+- **NEVER** log sensitive file contents in patterns
+- **NEVER** share patterns across user boundaries
+
+### Pattern Quality
+- **NEVER** record failed sessions as successful patterns
+- **NEVER** store patterns with confidence < 0.5
+- **NEVER** record incomplete workflows
+- **NEVER** overwrite high-confidence patterns with lower ones
+
+### Performance
+- **NEVER** call API when cache is fresh and relevant
+- **NEVER** skip `processingMode: 'offline-fallback'` for recall operations
+- **NEVER** generate embeddings client-side when API can do it
+- **NEVER** store duplicate patterns (use `detectDuplicates` first)
+
+## Required Patterns - MUST Follow
+
+### Memory Storage
+```javascript
+// MUST include these fields for workflow memories
+{
+  type: 'workflow',           // Required for behavior patterns
+  tags: [...],                // Required for filtering
+  metadata: {
+    confidence: 0.0-1.0,      // Required for ranking
+    directory: string,        // Required for context matching
+    project_type: string      // Required for project filtering
+  }
+}
+```
+
+### Pattern Recall
+```javascript
+// MUST use offline-fallback for recall operations
+const client = new MemoryIntelligenceClient({
+  processingMode: 'offline-fallback',
+  enableCache: true,
+  cacheTTL: 300000  // 5 minutes
+});
+```
+
+### Confidence Scoring
+```javascript
+// MUST calculate confidence based on outcome
+function calculateConfidence(outcome) {
+  let confidence = 0.5;  // Base
+
+  if (outcome.userExplicitApproval) confidence += 0.3;
+  if (outcome.noErrors) confidence += 0.1;
+  if (outcome.completedAllSteps) confidence += 0.1;
+
+  return Math.min(confidence, 1.0);
+}
+```
+
+## Integration with Other Skills
+
+| Skill | Integration Point |
+|-------|-------------------|
+| `skill-base-client.md` | Record API call patterns |
+| `skill-compliance-manager.md` | Filter sensitive data before storage |
+| `skill-metrics-collector.md` | Track pattern usage metrics |
+| `skill-version-manager.md` | Version-tag workflow patterns |
+
+## Hook Integration
+
+### Claude Code Session Hooks
+
+```javascript
+// .claude/hooks/behavior-memory.js
+module.exports = {
+  // Pre-session: Inject relevant patterns
+  'session:start': async (ctx) => {
+    const patterns = await recallPatterns(ctx);
+    return { inject: formatPatternsForContext(patterns) };
+  },
+
+  // Post-tool: Track tool usage
+  'tool:complete': async (ctx, tool, result) => {
+    trackToolUsage(ctx.sessionId, tool, result);
+  },
+
+  // Post-session: Store successful patterns
+  'session:end': async (ctx, outcome) => {
+    if (outcome.success) {
+      await storePattern(ctx, outcome);
+    }
+  }
+};
+```
+
+## Workflow Memory Schema
+
+```typescript
+interface WorkflowMemory {
+  // Standard fields
+  id: string;
+  user_id: string;
+  title: string;           // "Workflow: [task summary]"
+  content: string;         // JSON stringified WorkflowContent
+  type: 'workflow';
+  tags: string[];
+
+  // Metadata
+  metadata: {
+    confidence: number;    // 0.0 - 1.0
+    directory: string;     // Working directory
+    project_type: string;  // e.g., "typescript-api"
+    use_count: number;     // Times this pattern was recalled
+    last_used: string;     // ISO timestamp
+  };
+
+  // Auto-generated
+  embedding?: number[];    // Vector for semantic search
+  created_at: string;
+  updated_at: string;
+}
+
+interface WorkflowContent {
+  trigger: string;         // What initiated this workflow
+  actions: ToolAction[];   // Sequence of tool calls
+  outcome: string;         // Final result summary
+  duration_ms: number;     // How long it took
+}
+
+interface ToolAction {
+  tool: string;            // Tool name
+  parameters: object;      // Parameters used
+  outcome: 'success' | 'partial' | 'failed';
+  timestamp: string;
+}
+```
+
+## Testing Behavior Memory
+
+```bash
+# 1. Test pattern analysis
+curl -s -X POST "https://api.lanonasis.com/api/v1/intelligence/analyze-patterns" \
+  -H "X-API-Key: lano_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{"userId": "uuid", "timeRangeDays": 30}'
+
+# 2. Test insight extraction for workflows
+curl -s -X POST "https://api.lanonasis.com/api/v1/intelligence/extract-insights" \
+  -H "X-API-Key: lano_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{"userId": "uuid", "memoryType": "workflow", "maxMemories": 10}'
+
+# 3. Test related memory search
+curl -s -X POST "https://api.lanonasis.com/api/v1/intelligence/find-related" \
+  -H "X-API-Key: lano_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{"memoryId": "uuid", "userId": "uuid", "similarityThreshold": 0.7}'
+```
+
+## Rollback Procedure
+
+If behavior patterns cause issues:
+
+1. **Clear cache**
+   ```javascript
+   client.clearCache();
+   ```
+
+2. **Switch to API-only mode**
+   ```javascript
+   const client = new MemoryIntelligenceClient({
+     processingMode: 'api'  // Bypass local cache
+   });
+   ```
+
+3. **Delete problematic patterns**
+   ```javascript
+   await client.httpClient.delete(`/memories/${memoryId}`);
+   ```
+
+4. **Reset to clean state**
+   ```javascript
+   // Get all workflow memories
+   const workflows = await client.queryMemories(userId, { type: 'workflow' });
+
+   // Delete patterns with low confidence
+   for (const w of workflows.filter(w => w.metadata.confidence < 0.5)) {
+     await client.httpClient.delete(`/memories/${w.id}`);
+   }
+   ```
+
+## Evolution Roadmap
+
+The `@lanonasis/mem-intel-sdk` v2.0 should add these tools:
+
+| Tool | Purpose | Priority |
+|------|---------|----------|
+| `behavior_record` | Store workflow patterns | High |
+| `behavior_recall` | Query patterns for context | High |
+| `behavior_suggest` | Predict next actions | Medium |
+| `behavior_prune` | Remove stale patterns | Low |
+
+These will complement the existing analysis tools to complete the behavior learning cycle.

--- a/.claude/skills/skill-behavior-memory.md
+++ b/.claude/skills/skill-behavior-memory.md
@@ -6,6 +6,86 @@ This skill teaches AI agents to leverage `@lanonasis/mem-intel-sdk` for **behavi
 
 **Key Principle**: Local-first processing with cached embeddings. API calls are fallback, not primary.
 
+## API Reference
+
+Base URL: `https://api.lanonasis.com/api/v1`
+
+| Operation | Endpoint | Method | Description |
+|-----------|----------|--------|-------------|
+| Store pattern | `/memories` | POST | Create with `type: workflow` |
+| Recall patterns | `/memories/search` | POST | Semantic search with `type: workflow` |
+| List patterns | `/memories?type=workflow` | GET | Filter by workflow type |
+| Update pattern | `/memories/{id}` | PUT | Update use_count in metadata |
+| Delete pattern | `/memories/{id}` | DELETE | Remove stale patterns |
+| Analyze patterns | `/intelligence/analyze-patterns` | POST | mem-intel-sdk |
+| Find related | `/intelligence/find-related` | POST | mem-intel-sdk |
+| Extract insights | `/intelligence/extract-insights` | POST | mem-intel-sdk |
+
+### Authentication (3 methods)
+```
+OAuth2 PKCE (Primary): Authorization header with token
+API Key (Fallback):    X-API-Key: lano_*
+JWT (Legacy):          Authorization: Bearer <jwt>
+```
+
+### MemoryType Enum
+```typescript
+type MemoryType = 'context' | 'project' | 'knowledge' | 'reference' | 'personal' | 'workflow';
+//                                                                                  ^^^^^^^^
+//                                                                      Use this for behavior patterns
+```
+
+### API Payload Examples
+
+**Record Pattern (POST /memories)**
+```json
+{
+  "title": "Workflow: Fix authentication bug in TypeScript API",
+  "content": "{\"trigger\":\"fix auth bug\",\"actions\":[{\"tool\":\"Read\",\"outcome\":\"success\"},{\"tool\":\"Edit\",\"outcome\":\"success\"},{\"tool\":\"Bash\",\"outcome\":\"success\"}],\"final_outcome\":\"success\",\"duration_ms\":45000}",
+  "type": "workflow",
+  "tags": ["auth", "bugfix", "typescript-api"],
+  "metadata": {
+    "confidence": 0.85,
+    "use_count": 1,
+    "context": {
+      "directory": "/home/user/onasis-gateway",
+      "project_type": "typescript-api",
+      "branch": "main"
+    }
+  }
+}
+```
+
+**Recall Patterns (POST /memories/search)**
+```json
+{
+  "query": "fix authentication bug in typescript",
+  "type": "workflow",
+  "threshold": 0.7,
+  "limit": 5
+}
+```
+
+**Response Structure**
+```json
+{
+  "success": true,
+  "data": {
+    "results": [
+      {
+        "id": "uuid",
+        "title": "Workflow: Fix auth bug",
+        "content": "...",
+        "type": "workflow",
+        "similarity_score": 0.89,
+        "metadata": { "confidence": 0.85, "use_count": 3 }
+      }
+    ],
+    "total": 1
+  }
+}
+```
+
 ## Architecture Understanding
 
 ```

--- a/.claude/skills/skill-compliance-manager.md
+++ b/.claude/skills/skill-compliance-manager.md
@@ -1,0 +1,297 @@
+# Skill: Compliance Manager Guardian
+
+## Purpose & Scope
+
+This skill applies when modifying the **Compliance Manager** (`core/security/compliance-manager.js`).
+
+The Compliance Manager provides:
+- PCI-DSS data protection (card data masking, encryption)
+- GDPR compliance (pseudonymization, consent management, data minimization)
+- PSD2 compliance (Strong Customer Authentication)
+- SOX audit trail requirements
+- HIPAA health data protection
+- Multi-regulation validation framework
+- Secure audit logging
+
+## Critical Rules - NEVER Do
+
+### Compliance Validators
+- **NEVER** disable or bypass compliance validators
+- **NEVER** weaken validation rules (e.g., making required checks optional)
+- **NEVER** skip validation for "trusted" sources
+- **NEVER** add bypass flags or debug modes that skip compliance
+
+### PCI-DSS Rules
+- **NEVER** log these PCI fields (even in debug mode):
+  - `cvv`, `cvv2`, `cvc`, `cvc2`, `cid`, `cav2`
+  - `pin`, `pinBlock`
+  - `track1`, `track2`, `magneticStripe`
+- **NEVER** weaken card masking:
+  - MUST show only first 6 and last 4 digits
+  - Middle digits MUST be masked with `*`
+- **NEVER** reduce encryption below AES-256-GCM
+- **NEVER** store CVV/PIN after authorization
+
+### GDPR Rules
+- **NEVER** process personal data without consent check
+- **NEVER** skip pseudonymization for personal identifiers
+- **NEVER** retain personal data beyond retention period
+- **NEVER** disable data minimization for analytics
+
+### PSD2 Rules
+- **NEVER** reduce SCA requirements below 2 factors
+- **NEVER** bypass SCA for amounts over threshold
+- **NEVER** skip transaction monitoring for high-value transactions
+- **NEVER** disable cumulative amount tracking
+
+### Audit Logging
+- **NEVER** skip audit logging for sensitive operations
+- **NEVER** delete or modify existing audit entries
+- **NEVER** log sensitive data in audit trails (mask first)
+- **NEVER** disable audit persistence
+
+### Security Rollback
+- **NEVER** rollback security fixes without security team approval
+- **NEVER** lower security levels in production
+
+## Required Patterns - MUST Follow
+
+### Card Number Masking
+```javascript
+// MUST mask showing only first 6 and last 4
+maskCardNumber(cardNumber) {
+    const cleaned = cardNumber.replace(/\D/g, '');
+    const first6 = cleaned.substring(0, 6);
+    const last4 = cleaned.substring(cleaned.length - 4);
+    const masked = '*'.repeat(cleaned.length - 10);
+    return `${first6}${masked}${last4}`;
+}
+// Example: 4111111111111111 -> 411111******1111
+```
+
+### Data Encryption
+```javascript
+// MUST use AES-256-GCM
+encryptSensitiveData(data) {
+    const algorithm = 'aes-256-gcm';  // DO NOT change
+    const key = process.env.ENCRYPTION_KEY;
+    const iv = crypto.randomBytes(16);
+
+    const cipher = crypto.createCipher(algorithm, key);
+    cipher.setAAD(Buffer.from('compliance-encryption'));
+
+    // Return encrypted with IV and auth tag
+    return {
+        encrypted,
+        iv: iv.toString('hex'),
+        authTag: authTag.toString('hex'),
+        algorithm
+    };
+}
+```
+
+### Strong Customer Authentication
+```javascript
+// MUST require 2+ factors
+validateSCA(data) {
+    const factors = [];
+
+    if (data.password || data.pin) factors.push('knowledge');
+    if (data.deviceId || data.token) factors.push('possession');
+    if (data.biometric || data.fingerprint) factors.push('inherence');
+
+    return factors.length >= 2;  // PSD2 requirement
+}
+```
+
+### Defense in Depth
+```javascript
+// MUST apply all applicable protections
+enforceDataHandling(serviceId, data, operation) {
+    let processedData = { ...data };
+
+    // Apply ALL applicable protections - not just one
+    if (service?.compliance?.pci) {
+        processedData = this.applyPCIProtections(processedData, operation);
+    }
+    if (service?.compliance?.gdpr) {
+        processedData = this.applyGDPRProtections(processedData, operation);
+    }
+    if (service?.compliance?.psd2) {
+        processedData = this.applyPSD2Protections(processedData, operation);
+    }
+
+    return processedData;
+}
+```
+
+### Audit Entry Creation
+```javascript
+// MUST create audit entry for all compliance events
+logAuditEntry(action, details) {
+    const entry = {
+        timestamp: new Date(),
+        action,
+        details,
+        id: crypto.randomUUID()
+    };
+
+    this.auditLog.push(entry);
+    this.emit('audit:logged', entry);
+    this.persistAuditEntry(entry);  // MUST persist
+}
+```
+
+## Safe Modification Examples
+
+### Adding a New Regulation Validator
+```javascript
+// Add new validator class
+class NewRegulationValidator {
+    async validate(serviceConfig) {
+        const violations = [];
+        const recommendations = [];
+
+        // Add validation rules
+        if (!this.checkRequirement(serviceConfig)) {
+            violations.push('Regulation X.Y: Requirement description');
+        }
+
+        return {
+            compliant: violations.length === 0,
+            violations,
+            recommendations
+        };
+    }
+}
+
+// Register in constructor
+this.regulations = {
+    // ... existing validators
+    NEW_REG: new NewRegulationValidator()
+};
+```
+
+### Adding New PCI Protected Fields
+```javascript
+// Add to pciFields array - do NOT remove existing
+const pciFields = [
+    'cvv', 'pin', 'track1', 'track2', 'magneticStripe',
+    'newSensitiveField'  // ADD here
+];
+```
+
+### Adding New Consent Requirements
+```javascript
+// Extend consentRequiredFields - do NOT remove existing
+const consentRequiredFields = [
+    'email', 'phone', 'address', 'personalId',
+    'biometric', 'location', 'behavioralData',
+    'newPersonalDataField'  // ADD here
+];
+```
+
+### Adding Audit Entry Types
+```javascript
+// Add new audit action types
+this.logAuditEntry('NEW_COMPLIANCE_ACTION', {
+    serviceId,
+    details: 'What happened',
+    regulation: 'REGULATION_NAME'
+});
+```
+
+## Integration Points
+
+| Component | Integration Method |
+|-----------|-------------------|
+| Base Client | Data passed through `enforceDataHandling()` |
+| Metrics Collector | `compliance_violations_total` metric |
+| API Routes | Middleware for request validation |
+| Database | Audit entries persisted to `audit.compliance_log` |
+
+## Prohibited Fields Registry
+
+| Field | Regulation | Storage | Logging | Transmission |
+|-------|------------|---------|---------|--------------|
+| cvv, cvv2, cvc, cvc2 | PCI-DSS 3.2 | NEVER | NEVER | HTTPS only |
+| pin, pinBlock | PCI-DSS 3.4 | NEVER | NEVER | Encrypted |
+| track1, track2 | PCI-DSS 3.2 | NEVER | NEVER | NEVER |
+| magneticStripe | PCI-DSS 3.2 | NEVER | NEVER | NEVER |
+| Full card number | PCI-DSS 3.4 | Encrypted | Masked | Encrypted |
+
+## Testing Requirements
+
+Before any changes to this file:
+
+```bash
+# 1. Run compliance tests
+npm test -- --grep "ComplianceManager"
+
+# 2. Verify card masking
+node -e "
+const CM = require('./core/security/compliance-manager');
+const cm = new CM();
+console.log(cm.maskCardNumber('4111111111111111'));
+// Expected: 411111******1111
+"
+
+# 3. Test SCA validation
+node -e "
+const CM = require('./core/security/compliance-manager');
+const cm = new CM();
+console.log('1 factor:', cm.validateSCA({ password: 'x' }));  // false
+console.log('2 factors:', cm.validateSCA({ password: 'x', deviceId: 'y' }));  // true
+"
+
+# 4. Verify encryption uses AES-256-GCM
+# Check algorithm in encryptSensitiveData()
+```
+
+## Rollback Procedure
+
+**WARNING: Security fixes should NEVER be rolled back without security team approval.**
+
+If rollback is absolutely necessary:
+
+1. **Get Approval**
+   - Contact security team
+   - Document reason for rollback
+   - Get written approval
+
+2. **Conditional Rollback**
+   ```bash
+   # Only rollback non-security changes
+   git diff HEAD~1 core/security/compliance-manager.js | grep -E "encrypt|mask|validate"
+   # If any security functions changed, DO NOT rollback
+   ```
+
+3. **Verify Compliance**
+   ```javascript
+   const cm = new ComplianceManager();
+   const results = await cm.validateServiceCompliance(testConfig);
+   console.log('Overall:', results.overall);  // Must be COMPLIANT
+   ```
+
+4. **Audit the Rollback**
+   ```javascript
+   cm.logAuditEntry('COMPLIANCE_ROLLBACK', {
+       reason: 'Documented reason',
+       approvedBy: 'Security team member',
+       date: new Date()
+   });
+   ```
+
+## Compliance Validation Checklist
+
+Before deploying changes:
+
+- [ ] All card data properly masked (first 6, last 4 only)
+- [ ] CVV/PIN never logged or stored
+- [ ] Encryption uses AES-256-GCM
+- [ ] SCA requires 2+ factors
+- [ ] Audit entries created for all operations
+- [ ] GDPR consent check in place
+- [ ] Data minimization applied for analytics
+- [ ] No PII in metric labels
+- [ ] Audit log persisted to secure storage

--- a/.claude/skills/skill-metrics-collector.md
+++ b/.claude/skills/skill-metrics-collector.md
@@ -1,0 +1,257 @@
+# Skill: Metrics Collector Guardian
+
+## Purpose & Scope
+
+This skill applies when modifying the **Metrics Collector** (`core/monitoring/metrics-collector.js`).
+
+The Metrics Collector provides:
+- Prometheus-compatible metrics collection
+- Request/response/error tracking
+- Circuit breaker state monitoring
+- Rate limiting metrics
+- Business transaction metrics
+- Alert rule management
+- Metric buffering and batch processing
+
+## Critical Rules - NEVER Do
+
+### Metric Names
+- **NEVER** remove or rename existing Prometheus metric names:
+  - `api_requests_total`
+  - `api_request_duration_seconds`
+  - `api_errors_total`
+  - `api_error_rate`
+  - `api_response_size_bytes`
+  - `api_concurrent_requests`
+  - `circuit_breaker_state`
+  - `circuit_breaker_failures_total`
+  - `rate_limit_hits_total`
+  - `rate_limit_remaining`
+  - `auth_attempts_total`
+  - `token_refreshes_total`
+  - `compliance_violations_total`
+  - `data_processing_events_total`
+  - `transaction_volume_total`
+  - `transaction_value_total`
+  - `service_health_status`
+  - `dependency_health_status`
+
+### Label Stability
+- **NEVER** remove or rename labels on existing metrics
+- **NEVER** add new required labels to existing metrics (breaks dashboards)
+- **NEVER** change label value formats (e.g., `200` vs `"200"`)
+
+### Cardinality
+- **NEVER** create unbounded cardinality labels:
+  - No `transaction_id` labels (unique per request)
+  - No `user_id` labels (high cardinality)
+  - No `request_id` labels (unique per request)
+  - No `timestamp` labels (infinite values)
+
+### PII in Metrics
+- **NEVER** put PII in metric labels:
+  - No email addresses
+  - No user names
+  - No IP addresses (unless explicitly required)
+  - No account numbers
+
+### Histogram Buckets
+- **NEVER** change existing histogram bucket boundaries
+- Duration buckets: `[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30]`
+- Size buckets: `[100, 1000, 10000, 100000, 1000000, 10000000]`
+
+## Required Patterns - MUST Follow
+
+### Metric Registration
+```javascript
+// MUST register with proper name, help, labelNames
+this.metrics.metricName = new this.prometheus.Counter({
+    name: 'metric_name_total',
+    help: 'Clear description of what this metric measures',
+    labelNames: ['service', 'endpoint', 'method'],
+    registers: [this.register]
+});
+```
+
+### Event Emission After Recording
+```javascript
+// MUST emit events after recording metrics
+recordRequest(context) {
+    this.metrics.requestsTotal.inc(labels);
+    this.emit('metric:request', context);  // REQUIRED
+}
+```
+
+### Label Value Consistency
+```javascript
+// MUST use consistent label values
+const labels = {
+    service: context.service,        // lowercase, snake_case
+    endpoint: context.endpoint,      // /path/to/endpoint format
+    method: context.method,          // uppercase: GET, POST, etc.
+    status_code: context.statusCode  // numeric as string
+};
+```
+
+### Error Type Classification
+```javascript
+// MUST use standard error type classification
+getErrorType(statusCode) {
+    if (statusCode >= 400 && statusCode < 500) return 'client_error';
+    if (statusCode >= 500) return 'server_error';
+    return 'unknown_error';
+}
+```
+
+### Circuit Breaker State Values
+```javascript
+// MUST use numeric state values for Prometheus
+const stateValue = { 'CLOSED': 0, 'OPEN': 1, 'HALF_OPEN': 2 }[state] || 0;
+```
+
+## Safe Modification Examples
+
+### Adding a New Counter Metric
+```javascript
+// Add in initializeMetrics()
+this.metrics.newMetric = new this.prometheus.Counter({
+    name: 'onasis_new_metric_total',  // Use prefix for namespacing
+    help: 'Description of what this measures',
+    labelNames: ['service', 'type'],   // Keep labels bounded
+    registers: [this.register]
+});
+
+// Add recording method
+recordNewMetric(service, type) {
+    this.metrics.newMetric.labels(service, type).inc();
+    this.emit('metric:new_metric', { service, type });
+}
+```
+
+### Adding a New Histogram Metric
+```javascript
+// Use standard bucket sizes
+this.metrics.newHistogram = new this.prometheus.Histogram({
+    name: 'onasis_new_histogram_seconds',
+    help: 'Description',
+    labelNames: ['service', 'operation'],
+    buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10],
+    registers: [this.register]
+});
+```
+
+### Adding a New Gauge Metric
+```javascript
+this.metrics.newGauge = new this.prometheus.Gauge({
+    name: 'onasis_new_gauge',
+    help: 'Current value of something',
+    labelNames: ['service'],
+    registers: [this.register]
+});
+
+// Set value
+this.metrics.newGauge.labels('my-service').set(42);
+```
+
+### Adding a New Alert Rule
+```javascript
+this.addAlertRule('high-error-rate',
+    (type, data) => {
+        return type === 'error' && data.errorRate > 10;
+    },
+    (name, type, data) => {
+        console.error(`Alert ${name}: Error rate ${data.errorRate}%`);
+        this.emit('alert:triggered', { name, type, data });
+    }
+);
+```
+
+## Integration Points
+
+| Component | Integration Method |
+|-----------|-------------------|
+| Base Client | Emits `request`, `response`, `error` events |
+| Compliance Manager | Records compliance violations |
+| Version Manager | Version label in request metrics |
+| Prometheus | `getMetrics()` endpoint for scraping |
+| Grafana | Query metrics via PromQL |
+
+## Metric Export Format
+
+```
+# HELP api_requests_total Total number of API requests
+# TYPE api_requests_total counter
+api_requests_total{service="stripe-api",endpoint="/v1/charges",method="POST",status_code="200",version="v1"} 1523
+
+# HELP api_request_duration_seconds API request duration in seconds
+# TYPE api_request_duration_seconds histogram
+api_request_duration_seconds_bucket{service="stripe-api",endpoint="/v1/charges",method="POST",le="0.1"} 1200
+api_request_duration_seconds_bucket{service="stripe-api",endpoint="/v1/charges",method="POST",le="0.5"} 1450
+```
+
+## Testing Requirements
+
+Before any changes to this file:
+
+```bash
+# 1. Run metrics tests
+npm test -- --grep "MetricsCollector"
+
+# 2. Verify metric registration
+node -e "
+const MC = require('./core/monitoring/metrics-collector');
+const mc = new MC();
+console.log('Metrics registered:', Object.keys(mc.metrics).length);
+"
+
+# 3. Test Prometheus output format
+node -e "
+const MC = require('./core/monitoring/metrics-collector');
+const mc = new MC();
+mc.getMetrics().then(m => console.log(m.substring(0, 500)));
+"
+
+# 4. Verify event emission
+const mc = new MetricsCollector();
+mc.on('metric:request', (data) => console.log('Event received:', data));
+mc.recordRequest({ service: 'test', endpoint: '/test', method: 'GET', statusCode: 200 });
+```
+
+## Rollback Procedure
+
+If changes cause issues:
+
+1. **Immediate Rollback**
+   ```bash
+   git checkout HEAD~1 -- core/monitoring/metrics-collector.js
+   ```
+
+2. **Verify Metrics**
+   ```bash
+   curl http://localhost:3001/metrics | head -50
+   ```
+
+3. **Check Grafana Dashboards**
+   - Verify all panels still loading
+   - Check for "No data" errors
+   - Verify label filters still work
+
+4. **Alert Rule Check**
+   ```javascript
+   const mc = new MetricsCollector();
+   console.log('Alert rules:', mc.alertRules.size);
+   ```
+
+## Cardinality Guidelines
+
+| Label | Acceptable Values | Max Cardinality |
+|-------|-------------------|-----------------|
+| service | Service names | ~50 |
+| endpoint | API paths | ~200 per service |
+| method | GET, POST, PUT, DELETE, PATCH | 5 |
+| status_code | HTTP status codes | ~20 |
+| error_type | client_error, server_error, unknown_error | 3 |
+| auth_type | bearer, apikey, basic, hmac, oauth2 | 5 |
+| regulation | PCI_DSS, GDPR, PSD2, SOX, HIPAA | 5 |
+
+**Total expected cardinality per metric**: < 10,000 unique label combinations

--- a/.claude/skills/skill-vendor-abstraction.md
+++ b/.claude/skills/skill-vendor-abstraction.md
@@ -1,0 +1,264 @@
+# Skill: Vendor Abstraction Guardian
+
+## Purpose & Scope
+
+This skill applies when modifying the **Vendor Abstraction Layer** (`core/abstraction/vendor-abstraction.js`).
+
+The Vendor Abstraction Layer provides:
+- Isolation between client requests and vendor-specific implementations
+- Schema validation for client inputs
+- Transform functions to convert client input to vendor format
+- Multi-vendor support with fallback capabilities
+- Category-based service organization (payment, banking, infrastructure)
+
+## Critical Rules - NEVER Do
+
+### Schema Isolation
+- **NEVER** expose vendor-specific field names in client schema
+  - Client schema uses: `firstName`, `lastName`
+  - Vendor may use: `first_name`, `last_name` (hidden from client)
+- **NEVER** let vendor response leak directly to client without transformation
+- **NEVER** add vendor-specific validation in client schema
+
+### Vendor Selection
+- **NEVER** hardcode vendor selection logic in business code
+- **NEVER** remove a vendor without 30-day deprecation notice
+- **NEVER** make vendor selection observable from client input
+- **NEVER** expose vendor identifiers in client-facing responses
+
+### Schema Stability
+- **NEVER** add required fields to existing client schemas (breaking change)
+- **NEVER** remove fields from existing client schemas
+- **NEVER** change field types in existing client schemas
+- **NEVER** rename fields in existing client schemas
+
+### Category Management
+- **NEVER** remove a category without migrating all operations
+- **NEVER** merge categories (maintain separation of concerns)
+- **NEVER** duplicate operations across categories
+
+## Required Patterns - MUST Follow
+
+### Client Schema Definition
+```javascript
+// MUST define schema with type and required flag
+client: {
+    operationName: {
+        schema: {
+            fieldName: { type: 'string', required: true },
+            optionalField: { type: 'number', required: false },
+            defaultedField: { type: 'string', default: 'value' }
+        }
+    }
+}
+```
+
+### Vendor Transform Functions
+```javascript
+// MUST use pure functions for transforms
+// Input: client schema -> Output: vendor-specific format
+transform: (input) => ({
+    vendor_field: input.clientField,
+    vendor_amount: input.amount * 100,  // Unit conversion here
+    reference: input.reference || `prefix_${Date.now()}`
+})
+```
+
+### Vendor Fallback Pattern
+```javascript
+// MUST have fallback vendor for critical categories
+const vendors = Object.keys(abstraction.vendors);
+const selectedVendor = vendorPreference && vendors.includes(vendorPreference)
+    ? vendorPreference
+    : vendors[0];  // Fallback to first available
+```
+
+### Input Validation
+```javascript
+// MUST validate before vendor call
+this.validateInput(input, clientSchema.schema);
+
+// Validation MUST check:
+// 1. Required fields present
+// 2. Field types match schema
+// 3. Apply defaults for missing optional fields
+```
+
+### Vendor Isolation
+```javascript
+// Client input NEVER touches vendor code directly
+// Flow: client input -> validation -> transform -> vendor call
+async executeAbstractedCall(category, operation, input, vendorPreference) {
+    const abstraction = this.vendorMappings.get(category);
+    this.validateInput(input, abstraction.client[operation].schema);
+    const vendorInput = mapping.transform(input);  // Isolation point
+    return await this.executeVendorCall(vendorConfig.adapter, mapping.tool, vendorInput);
+}
+```
+
+## Safe Modification Examples
+
+### Adding a New Vendor
+```javascript
+// Add to existing category - do NOT modify client schema
+vendors: {
+    'existing-vendor': { /* keep unchanged */ },
+    'new-vendor': {
+        adapter: 'new-vendor-api',
+        mappings: {
+            initializeTransaction: {
+                tool: 'create-payment',
+                transform: (input) => ({
+                    // Map from client schema to vendor format
+                    customer_email: input.email,
+                    payment_amount: input.amount,
+                    // ... vendor-specific fields
+                })
+            }
+        }
+    }
+}
+```
+
+### Adding a New Operation to Existing Category
+```javascript
+// Add to client schema with OPTIONAL fields only
+client: {
+    existingOperation: { /* keep unchanged */ },
+    newOperation: {
+        schema: {
+            requiredField: { type: 'string', required: true },
+            // All NEW operations can have required fields
+        }
+    }
+}
+
+// Add mappings to ALL vendors
+vendors: {
+    'vendor1': {
+        mappings: {
+            existingOperation: { /* unchanged */ },
+            newOperation: { /* add here */ }
+        }
+    },
+    'vendor2': {
+        mappings: {
+            newOperation: { /* must also add here */ }
+        }
+    }
+}
+```
+
+### Adding a New Category
+```javascript
+this.registerAbstraction('newCategory', {
+    client: {
+        operationName: {
+            schema: {
+                field: { type: 'string', required: true }
+            }
+        }
+    },
+    vendors: {
+        'primary-vendor': {
+            adapter: 'vendor-api',
+            mappings: {
+                operationName: {
+                    tool: 'vendor-tool-name',
+                    transform: (input) => ({ /* mapping */ })
+                }
+            }
+        }
+    }
+});
+```
+
+## Integration Points
+
+| Component | Integration Method |
+|-----------|-------------------|
+| Base Client | Vendor calls routed through `executeVendorCall()` |
+| MCP Server | Categories exposed as tool groups |
+| REST API | Operations exposed as endpoints |
+| Metrics | Track per-vendor call metrics |
+
+## Vendor Deprecation Process
+
+When removing a vendor (30-day minimum):
+
+```javascript
+// Day 1: Mark as deprecated
+vendors: {
+    'old-vendor': {
+        adapter: 'old-vendor-api',
+        deprecated: true,
+        deprecationDate: '2024-01-15',
+        migrateTo: 'new-vendor',
+        mappings: { /* unchanged */ }
+    }
+}
+
+// Day 30+: Remove vendor
+// Remove 'old-vendor' from vendors object
+```
+
+## Testing Requirements
+
+Before any changes to this file:
+
+```bash
+# 1. Run abstraction tests
+npm test -- --grep "VendorAbstraction"
+
+# 2. Verify schema validation
+node -e "
+const VAL = require('./core/abstraction/vendor-abstraction');
+const val = new VAL();
+console.log('Categories:', val.getAvailableCategories());
+console.log('Payment ops:', val.getCategoryOperations('payment'));
+"
+
+# 3. Test each vendor transform
+# Verify output matches vendor API spec
+
+# 4. Test vendor fallback
+# Verify primary vendor failure falls back to secondary
+```
+
+## Rollback Procedure
+
+If changes cause issues:
+
+1. **Immediate Rollback**
+   ```bash
+   git checkout HEAD~1 -- core/abstraction/vendor-abstraction.js
+   ```
+
+2. **Verify Categories**
+   ```javascript
+   const val = new VendorAbstractionLayer();
+   console.log('Available categories:', val.getAvailableCategories());
+   // Expected: ['payment', 'banking', 'infrastructure']
+   ```
+
+3. **Test Critical Operations**
+   ```javascript
+   // Test payment flow
+   await val.executeAbstractedCall('payment', 'initializeTransaction', {
+       amount: 1000,
+       email: 'test@example.com'
+   });
+   ```
+
+## Client Schema Registry
+
+| Category | Operation | Required Fields | Optional Fields |
+|----------|-----------|-----------------|-----------------|
+| payment | initializeTransaction | amount, email | currency, reference, metadata |
+| payment | verifyTransaction | reference | |
+| payment | createCustomer | email | firstName, lastName, phone |
+| banking | getAccountBalance | accountId | |
+| banking | transferFunds | fromAccount, toAccount, amount | currency, reference |
+| banking | verifyAccount | accountNumber, bankCode | |
+| infrastructure | createTunnel | port | subdomain, region |
+| infrastructure | listTunnels | | |

--- a/.claude/skills/skill-version-manager.md
+++ b/.claude/skills/skill-version-manager.md
@@ -1,0 +1,309 @@
+# Skill: Version Manager Guardian
+
+## Purpose & Scope
+
+This skill applies when modifying the **Version Manager** (`core/versioning/version-manager.js`).
+
+The Version Manager provides:
+- Semantic versioning enforcement
+- Version compatibility analysis
+- Migration handler registration and execution
+- Version deprecation management
+- Breaking change detection
+- Compatibility matrix tracking
+
+## Critical Rules - NEVER Do
+
+### Version Lifecycle
+- **NEVER** delete versions without deprecation period (minimum 30 days)
+- **NEVER** skip the deprecation phase for any version
+- **NEVER** remove versions that are still in active use
+- **NEVER** change version registration timestamps retroactively
+
+### Semver Compliance
+- **NEVER** mark breaking changes as compatible
+- **NEVER** skip major version bump for breaking changes
+- **NEVER** allow non-semver version formats
+- **NEVER** bypass semver validation
+
+### Breaking Changes Classification
+- **NEVER** allow these changes in minor/patch versions:
+  - Removing endpoints
+  - Adding required parameters
+  - Changing parameter types
+  - Modifying authentication requirements
+  - Changing response structure
+
+### Migration Safety
+- **NEVER** skip version compatibility analysis
+- **NEVER** allow migrations without registered handlers
+- **NEVER** execute migrations without rollback capability
+- **NEVER** bypass migration validation
+
+### Compatibility Matrix
+- **NEVER** delete compatibility matrix entries
+- **NEVER** falsify compatibility status
+- **NEVER** hide breaking changes in compatibility reports
+
+## Required Patterns - MUST Follow
+
+### Semver Validation
+```javascript
+// MUST validate version format before registration
+registerVersion(serviceId, version, config) {
+    if (!semver.valid(version)) {
+        throw new Error(`Invalid version format: ${version}`);
+    }
+    // Continue with registration
+}
+```
+
+### Breaking Change Detection
+```javascript
+// MUST detect these as breaking changes:
+const breakingChangeTypes = [
+    'endpoint_removed',
+    'method_changed',
+    'path_changed',
+    'required_parameter_added',
+    'required_parameter_removed',
+    'parameter_type_changed',
+    'auth_type_changed',
+    'baseUrl_changed'
+];
+
+// Compatibility MUST be false if any breaking changes exist
+compatibility.compatible = compatibility.breakingChanges.length === 0;
+```
+
+### Version Registration
+```javascript
+// MUST include metadata on registration
+this.supportedVersions.set(key, {
+    ...config,
+    registeredAt: new Date(),
+    deprecated: false
+});
+
+// MUST create compatibility mappings
+this.createCompatibilityMappings(serviceId, version, config);
+
+// MUST emit registration event
+this.emit('version:registered', { serviceId, version, config });
+```
+
+### Deprecation Process
+```javascript
+// MUST follow deprecation protocol
+deprecateVersion(serviceId, version, reason) {
+    config.deprecated = true;
+    config.deprecationReason = reason;
+    config.deprecatedAt = new Date();
+
+    this.emit('version:deprecated', { serviceId, version, reason });
+}
+```
+
+### Migration Handler Registration
+```javascript
+// MUST register handlers for version transitions
+registerMigrationHandler(serviceId, fromVersion, toVersion, handler) {
+    const key = `${serviceId}:${fromVersion}->${toVersion}`;
+    this.migrationHandlers.set(key, handler);
+}
+```
+
+### Event Emission
+```javascript
+// MUST emit events for version lifecycle
+this.emit('version:registered', { serviceId, version, config });
+this.emit('version:deprecated', { serviceId, version, reason });
+this.emit('migration:completed', { serviceId, fromVersion, toVersion, data });
+this.emit('migration:failed', { serviceId, fromVersion, toVersion, error });
+```
+
+## Safe Modification Examples
+
+### Adding New Breaking Change Detection
+```javascript
+// Add to compareEndpoint() - do NOT remove existing checks
+compareEndpoint(newEndpoint, oldEndpoint) {
+    const changes = { breaking: [], migrations: [], warnings: [] };
+
+    // Existing checks...
+    if (newEndpoint.method !== oldEndpoint.method) {
+        changes.breaking.push({ type: 'method_changed', /* ... */ });
+    }
+
+    // ADD new checks here
+    if (newEndpoint.timeout !== oldEndpoint.timeout) {
+        changes.warnings.push({
+            type: 'timeout_changed',
+            message: `Timeout changed from ${oldEndpoint.timeout} to ${newEndpoint.timeout}`
+        });
+    }
+
+    return changes;
+}
+```
+
+### Adding Version Metadata Fields
+```javascript
+// Extend version config - do NOT remove existing fields
+this.supportedVersions.set(key, {
+    ...config,
+    registeredAt: new Date(),
+    deprecated: false,
+    newField: value  // ADD new fields here
+});
+```
+
+### Adding New Event Types
+```javascript
+// Add new events - do NOT modify existing event signatures
+this.emit('version:activated', { serviceId, version });
+this.emit('version:sunset', { serviceId, version, sunsetDate });
+```
+
+### Adding Compatibility Check Rules
+```javascript
+// Extend analyzeCompatibility() - do NOT remove existing checks
+analyzeCompatibility(newConfig, oldConfig) {
+    const compatibility = {
+        compatible: true,
+        breakingChanges: [],
+        migrations: [],
+        warnings: []
+    };
+
+    // Existing checks...
+    const endpointChanges = this.compareEndpoints(...);
+    const authChanges = this.compareAuthentication(...);
+
+    // ADD new checks
+    const headerChanges = this.compareHeaders(newConfig.headers, oldConfig.headers);
+    compatibility.warnings.push(...headerChanges.warnings);
+
+    return compatibility;
+}
+```
+
+## Integration Points
+
+| Component | Integration Method |
+|-----------|-------------------|
+| Base Client | Version passed in request options |
+| Metrics Collector | Version label in request metrics |
+| REST API | `/v{version}/` path prefix |
+| MCP Server | Version header in tool calls |
+| Vendor Abstraction | Version-specific vendor mappings |
+
+## Version Deprecation Timeline
+
+```
+Day 0:    Mark as deprecated, emit 'version:deprecated' event
+Day 1-7:  Log warnings for all requests using deprecated version
+Day 8-14: Return deprecation headers in responses
+Day 15-29: Increase warning severity
+Day 30+:  Safe to remove (after migration verification)
+```
+
+## Testing Requirements
+
+Before any changes to this file:
+
+```bash
+# 1. Run version manager tests
+npm test -- --grep "VersionManager"
+
+# 2. Verify semver validation
+node -e "
+const VM = require('./core/versioning/version-manager');
+const vm = new VM();
+try { vm.registerVersion('test', 'invalid', {}); }
+catch(e) { console.log('Correctly rejected invalid version'); }
+vm.registerVersion('test', '1.0.0', { endpoints: [] });
+console.log('Valid version accepted');
+"
+
+# 3. Test breaking change detection
+node -e "
+const VM = require('./core/versioning/version-manager');
+const vm = new VM();
+const result = vm.analyzeCompatibility(
+    { endpoints: [] },
+    { endpoints: [{ id: 'removed', path: '/test' }] }
+);
+console.log('Breaking changes detected:', result.breakingChanges.length);
+"
+
+# 4. Test migration handler
+node -e "
+const VM = require('./core/versioning/version-manager');
+const vm = new VM();
+vm.registerMigrationHandler('test', '1.0.0', '2.0.0', async (data) => {
+    return { ...data, migrated: true };
+});
+console.log('Migration handler registered');
+"
+```
+
+## Rollback Procedure
+
+If changes cause issues:
+
+1. **Immediate Rollback**
+   ```bash
+   git checkout HEAD~1 -- core/versioning/version-manager.js
+   ```
+
+2. **Verify Version Registry**
+   ```javascript
+   const vm = new VersionManager();
+   vm.registerVersion('test', '1.0.0', { endpoints: [] });
+   console.log('Versions:', vm.getServiceVersions('test'));
+   ```
+
+3. **Check Compatibility Matrix**
+   ```javascript
+   const vm = new VersionManager();
+   // Register test versions
+   vm.registerVersion('test', '1.0.0', { endpoints: [] });
+   vm.registerVersion('test', '2.0.0', { endpoints: [] });
+   console.log('Matrix:', vm.getCompatibilityMatrix('test'));
+   ```
+
+4. **Verify Events**
+   ```javascript
+   const vm = new VersionManager();
+   vm.on('version:registered', (data) => console.log('Event works:', data));
+   vm.registerVersion('test', '1.0.0', {});
+   ```
+
+## Breaking Change Reference
+
+| Change Type | Severity | Version Bump | Migration Required |
+|-------------|----------|--------------|-------------------|
+| Endpoint removed | BREAKING | Major | Yes |
+| Method changed | BREAKING | Major | Yes |
+| Path changed | BREAKING | Major | Yes |
+| Required param added | BREAKING | Major | Yes |
+| Required param removed | BREAKING | Major | Yes |
+| Param type changed | BREAKING | Major | Yes |
+| Auth type changed | BREAKING | Major | Yes |
+| Optional param added | Compatible | Minor | No |
+| New endpoint added | Compatible | Minor | No |
+| Bug fix | Compatible | Patch | No |
+
+## Version Status Lifecycle
+
+```
+REGISTERED -> ACTIVE -> DEPRECATED -> REMOVED
+     ↑           ↓
+     └───────────┘ (rollback possible before deprecation)
+```
+
+- **REGISTERED**: Version exists but may not be in use
+- **ACTIVE**: Version is in production use
+- **DEPRECATED**: Marked for removal, deprecation period started
+- **REMOVED**: Version no longer supported (30+ days after deprecation)

--- a/services/memory-as-a-service/context-patterns/01-sdk-upgrade-guide.md
+++ b/services/memory-as-a-service/context-patterns/01-sdk-upgrade-guide.md
@@ -1,0 +1,648 @@
+# SDK Upgrade Guide: mem-intel-sdk v1.x → v2.0
+
+## Overview
+
+This guide provides the exact code changes needed to upgrade `@lanonasis/mem-intel-sdk` to v2.0 with behavior intelligence.
+
+## File Changes Summary
+
+| File | Action | Lines Added |
+|------|--------|-------------|
+| `core/types.ts` | Extend | ~80 lines |
+| `core/client.ts` | Extend | ~150 lines |
+| `utils/similarity.ts` | No change | (already exists) |
+| `package.json` | Update version | 1 line |
+
+---
+
+## 1. Type Definitions (`core/types.ts`)
+
+Add these types after the existing type definitions:
+
+```typescript
+// =============================================================================
+// BEHAVIOR INTELLIGENCE TYPES (v2.0)
+// =============================================================================
+
+/**
+ * Outcome status for tool actions and workflows
+ */
+export type BehaviorOutcome = 'success' | 'partial' | 'failed';
+
+/**
+ * Individual tool action within a workflow
+ */
+export interface ToolAction {
+  /** Tool name (e.g., "Read", "Edit", "Bash") */
+  tool: string;
+  /** Parameters passed to the tool */
+  parameters: Record<string, unknown>;
+  /** Outcome of the tool execution */
+  outcome: BehaviorOutcome;
+  /** ISO timestamp when action occurred */
+  timestamp: string;
+  /** Execution duration in milliseconds */
+  duration_ms?: number;
+}
+
+/**
+ * Stored workflow pattern for behavior learning
+ */
+export interface WorkflowPattern {
+  id: string;
+  user_id: string;
+  /** What triggered this workflow (user prompt/task) */
+  trigger: string;
+  /** Vector embedding of trigger for semantic search */
+  trigger_embedding?: number[];
+  /** Context when workflow was executed */
+  context: {
+    directory: string;
+    project_type?: string;
+    branch?: string;
+    files_touched?: string[];
+  };
+  /** Sequence of tool actions */
+  actions: ToolAction[];
+  /** Final outcome of the workflow */
+  final_outcome: BehaviorOutcome;
+  /** Confidence score (0.0 - 1.0) */
+  confidence: number;
+  /** Number of times this pattern was recalled/used */
+  use_count: number;
+  /** Last time pattern was recalled */
+  last_used_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Parameters for recording a behavior pattern
+ */
+export interface BehaviorRecordParams {
+  userId: string;
+  /** What triggered this workflow */
+  trigger: string;
+  /** Execution context */
+  context: {
+    directory: string;
+    projectType?: string;
+    branch?: string;
+    filesTouched?: string[];
+  };
+  /** Actions performed */
+  actions: ToolAction[];
+  /** Final outcome */
+  finalOutcome: BehaviorOutcome;
+  /** Confidence score (default: 0.7) */
+  confidence?: number;
+}
+
+/**
+ * Parameters for recalling behavior patterns
+ */
+export interface BehaviorRecallParams {
+  userId: string;
+  /** Current context for matching */
+  context: {
+    currentDirectory: string;
+    currentTask: string;
+    projectType?: string;
+  };
+  /** Maximum patterns to return */
+  limit?: number;
+  /** Minimum similarity threshold (0.0 - 1.0) */
+  similarityThreshold?: number;
+}
+
+/**
+ * Parameters for behavior suggestions
+ */
+export interface BehaviorSuggestParams {
+  userId: string;
+  /** Current execution state */
+  currentState: {
+    taskDescription: string;
+    completedSteps: string[];
+    currentFiles?: string[];
+  };
+  /** Maximum suggestions to return */
+  maxSuggestions?: number;
+}
+
+/**
+ * Result from recalling behavior patterns
+ */
+export interface BehaviorRecallResult {
+  patterns: Array<{
+    pattern: WorkflowPattern;
+    similarity_score: number;
+    relevance_reason: string;
+  }>;
+  total_found: number;
+}
+
+/**
+ * Individual behavior suggestion
+ */
+export interface BehaviorSuggestion {
+  /** Suggested action description */
+  action: string;
+  /** Tool to use */
+  tool: string;
+  /** Confidence in this suggestion */
+  confidence: number;
+  /** Pattern IDs this is based on */
+  based_on_patterns: string[];
+  /** Why this is suggested */
+  reasoning: string;
+}
+
+/**
+ * Result from behavior suggestions
+ */
+export interface BehaviorSuggestResult {
+  suggestions: BehaviorSuggestion[];
+}
+```
+
+---
+
+## 2. Client Methods (`core/client.ts`)
+
+Add these methods to the `MemoryIntelligenceClient` class:
+
+```typescript
+import { cosineSimilarity } from '../utils/similarity';
+
+// Add to MemoryIntelligenceClient class:
+
+// =============================================================================
+// BEHAVIOR INTELLIGENCE METHODS (v2.0)
+// =============================================================================
+
+/**
+ * Record a successful workflow pattern for future recall
+ * @param params - Recording parameters
+ * @returns Stored pattern with metadata
+ */
+async recordBehavior(params: BehaviorRecordParams): Promise<{
+  data: WorkflowPattern;
+  usage?: UsageInfo;
+}> {
+  // Check for duplicates locally first (deduplication)
+  if (this.processingMode === 'offline-fallback' && this.cache) {
+    const existing = await this.findSimilarBehavior(params.trigger, params.userId);
+    if (existing && existing.similarity > 0.95) {
+      // Update use_count instead of creating duplicate
+      return this.updateBehaviorUsage(existing.id);
+    }
+  }
+
+  // Store as workflow memory via existing endpoint
+  const response = await this.httpClient.postEnhanced(
+    '/memories',
+    {
+      title: `Workflow: ${params.trigger.substring(0, 50)}`,
+      content: JSON.stringify({
+        trigger: params.trigger,
+        actions: params.actions,
+        final_outcome: params.finalOutcome,
+        duration_ms: params.actions.reduce((sum, a) => sum + (a.duration_ms || 0), 0)
+      }),
+      type: 'workflow',
+      tags: this.extractBehaviorTags(params),
+      metadata: {
+        confidence: params.confidence || 0.7,
+        use_count: 1,
+        context: {
+          directory: params.context.directory,
+          project_type: params.context.projectType,
+          branch: params.context.branch,
+          files_touched: params.context.filesTouched
+        }
+      }
+    }
+  );
+
+  if (response.error) {
+    throw new DatabaseError(`Failed to record behavior: ${response.error.message}`);
+  }
+
+  return {
+    data: this.parseWorkflowPattern(response.data),
+    usage: response.usage
+  };
+}
+
+/**
+ * Recall relevant behavior patterns for current context
+ * Uses local-first approach with cached embeddings
+ * @param params - Recall parameters
+ * @returns Matching patterns with similarity scores
+ */
+async recallBehavior(params: BehaviorRecallParams): Promise<{
+  data: BehaviorRecallResult;
+  usage?: UsageInfo;
+  fromCache?: boolean;
+}> {
+  // Try local cache first (local-first principle)
+  if (this.processingMode === 'offline-fallback' && this.cache) {
+    const cached = await this.localBehaviorSearch(params);
+    if (cached.patterns.length > 0) {
+      return { data: cached, fromCache: true };
+    }
+  }
+
+  // Fall back to API search
+  const response = await this.httpClient.postEnhanced(
+    '/memories/search',
+    {
+      query: params.context.currentTask,
+      type: 'workflow',
+      threshold: params.similarityThreshold || 0.7,
+      limit: params.limit || 5
+    }
+  );
+
+  if (response.error) {
+    throw new DatabaseError(`Failed to recall behavior: ${response.error.message}`);
+  }
+
+  // Parse and cache results
+  const result = this.parseBehaviorRecallResult(response.data);
+
+  if (this.cache && result.patterns.length > 0) {
+    this.cacheBehaviorPatterns(result.patterns.map(p => p.pattern));
+  }
+
+  // Increment use_count for recalled patterns
+  for (const { pattern } of result.patterns) {
+    await this.incrementPatternUsage(pattern.id).catch(() => {
+      // Non-critical, log but don't fail
+    });
+  }
+
+  return {
+    data: result,
+    usage: response.usage,
+    fromCache: false
+  };
+}
+
+/**
+ * Get AI-powered suggestions for next actions based on patterns
+ * @param params - Suggestion parameters
+ * @returns Suggested next actions
+ */
+async suggestBehavior(params: BehaviorSuggestParams): Promise<{
+  data: BehaviorSuggestResult;
+  usage?: UsageInfo;
+}> {
+  // First recall relevant patterns
+  const recalled = await this.recallBehavior({
+    userId: params.userId,
+    context: {
+      currentDirectory: '',
+      currentTask: params.currentState.taskDescription,
+      projectType: undefined
+    },
+    limit: 10,
+    similarityThreshold: 0.6
+  });
+
+  // Analyze patterns to suggest next action
+  const suggestions = this.analyzePatternsForSuggestions(
+    recalled.data.patterns,
+    params.currentState
+  );
+
+  return {
+    data: { suggestions: suggestions.slice(0, params.maxSuggestions || 3) },
+    usage: recalled.usage
+  };
+}
+
+// =============================================================================
+// PRIVATE HELPER METHODS
+// =============================================================================
+
+/**
+ * Search behavior patterns locally using cached embeddings
+ */
+private async localBehaviorSearch(params: BehaviorRecallParams): Promise<BehaviorRecallResult> {
+  const cachedPatterns: WorkflowPattern[] = this.cache?.get('behavior_patterns') || [];
+
+  // Filter by context if specified
+  const contextMatches = cachedPatterns.filter((p: WorkflowPattern) => {
+    if (params.context.projectType && p.context.project_type !== params.context.projectType) {
+      return false;
+    }
+    return true;
+  });
+
+  // Semantic search on trigger text
+  const taskEmbedding = await this.getEmbedding(params.context.currentTask);
+
+  const scored = contextMatches.map((p: WorkflowPattern) => ({
+    pattern: p,
+    similarity_score: p.trigger_embedding
+      ? cosineSimilarity(taskEmbedding, p.trigger_embedding)
+      : 0,
+    relevance_reason: `Matched trigger: "${p.trigger.substring(0, 50)}..."`
+  }));
+
+  // Filter by threshold and sort by similarity
+  const filtered = scored
+    .filter(s => s.similarity_score >= (params.similarityThreshold || 0.7))
+    .sort((a, b) => b.similarity_score - a.similarity_score)
+    .slice(0, params.limit || 5);
+
+  return {
+    patterns: filtered,
+    total_found: filtered.length
+  };
+}
+
+/**
+ * Find similar behavior pattern by trigger text
+ */
+private async findSimilarBehavior(trigger: string, userId: string): Promise<{ id: string; similarity: number } | null> {
+  const cachedPatterns: WorkflowPattern[] = this.cache?.get('behavior_patterns') || [];
+  const userPatterns = cachedPatterns.filter(p => p.user_id === userId);
+
+  if (userPatterns.length === 0) return null;
+
+  const triggerEmbedding = await this.getEmbedding(trigger);
+
+  let bestMatch: { id: string; similarity: number } | null = null;
+
+  for (const pattern of userPatterns) {
+    if (!pattern.trigger_embedding) continue;
+
+    const similarity = cosineSimilarity(triggerEmbedding, pattern.trigger_embedding);
+    if (!bestMatch || similarity > bestMatch.similarity) {
+      bestMatch = { id: pattern.id, similarity };
+    }
+  }
+
+  return bestMatch;
+}
+
+/**
+ * Update use_count for an existing pattern
+ */
+private async updateBehaviorUsage(patternId: string): Promise<{
+  data: WorkflowPattern;
+  usage?: UsageInfo;
+}> {
+  const response = await this.httpClient.postEnhanced(
+    `/rpc/increment_pattern_use_count`,
+    { pattern_id: patternId }
+  );
+
+  if (response.error) {
+    throw new DatabaseError(`Failed to update behavior usage: ${response.error.message}`);
+  }
+
+  // Fetch updated pattern
+  const patternResponse = await this.httpClient.getEnhanced(`/memories/${patternId}`);
+
+  return {
+    data: this.parseWorkflowPattern(patternResponse.data),
+    usage: response.usage
+  };
+}
+
+/**
+ * Increment use_count for a pattern
+ */
+private async incrementPatternUsage(patternId: string): Promise<void> {
+  await this.httpClient.post(`/rpc/increment_pattern_use_count`, {
+    pattern_id: patternId
+  });
+}
+
+/**
+ * Cache behavior patterns for local search
+ */
+private cacheBehaviorPatterns(patterns: WorkflowPattern[]): void {
+  const existing: WorkflowPattern[] = this.cache?.get('behavior_patterns') || [];
+  const merged = [...existing];
+
+  for (const p of patterns) {
+    const idx = merged.findIndex(e => e.id === p.id);
+    if (idx >= 0) {
+      merged[idx] = p;
+    } else {
+      merged.push(p);
+    }
+  }
+
+  this.cache?.set('behavior_patterns', merged);
+}
+
+/**
+ * Get embedding for text (uses cache if available)
+ */
+private async getEmbedding(text: string): Promise<number[]> {
+  const cacheKey = `embedding:${text.substring(0, 100)}`;
+  const cached = this.cache?.get(cacheKey);
+  if (cached) return cached;
+
+  // Call embedding API
+  const response = await this.httpClient.post('/embeddings', { text });
+  const embedding = response.data?.embedding || [];
+
+  if (this.cache && embedding.length > 0) {
+    this.cache.set(cacheKey, embedding);
+  }
+
+  return embedding;
+}
+
+/**
+ * Extract tags from behavior params
+ */
+private extractBehaviorTags(params: BehaviorRecordParams): string[] {
+  const tags = ['behavior-pattern'];
+
+  if (params.context.projectType) {
+    tags.push(params.context.projectType);
+  }
+
+  // Extract tool names as tags
+  const tools = [...new Set(params.actions.map(a => a.tool.toLowerCase()))];
+  tags.push(...tools);
+
+  return tags;
+}
+
+/**
+ * Parse API response to WorkflowPattern
+ */
+private parseWorkflowPattern(data: any): WorkflowPattern {
+  const content = typeof data.content === 'string'
+    ? JSON.parse(data.content)
+    : data.content;
+
+  return {
+    id: data.id,
+    user_id: data.user_id,
+    trigger: content.trigger || data.title?.replace('Workflow: ', '') || '',
+    trigger_embedding: data.embedding,
+    context: data.metadata?.context || {},
+    actions: content.actions || [],
+    final_outcome: content.final_outcome || 'success',
+    confidence: data.metadata?.confidence || 0.7,
+    use_count: data.metadata?.use_count || 1,
+    last_used_at: data.metadata?.last_used_at,
+    created_at: data.created_at,
+    updated_at: data.updated_at
+  };
+}
+
+/**
+ * Parse API response to BehaviorRecallResult
+ */
+private parseBehaviorRecallResult(data: any): BehaviorRecallResult {
+  const results = data.results || [];
+
+  return {
+    patterns: results.map((r: any) => ({
+      pattern: this.parseWorkflowPattern(r),
+      similarity_score: r.similarity_score || 0,
+      relevance_reason: `Matched with ${Math.round((r.similarity_score || 0) * 100)}% similarity`
+    })),
+    total_found: data.total || results.length
+  };
+}
+
+/**
+ * Analyze recalled patterns to suggest next actions
+ */
+private analyzePatternsForSuggestions(
+  patterns: Array<{ pattern: WorkflowPattern; similarity_score: number }>,
+  currentState: { taskDescription: string; completedSteps: string[]; currentFiles?: string[] }
+): BehaviorSuggestion[] {
+  const suggestions: BehaviorSuggestion[] = [];
+  const completedCount = currentState.completedSteps.length;
+
+  for (const { pattern, similarity_score } of patterns) {
+    // Find the next action after current progress
+    if (pattern.actions.length > completedCount) {
+      const nextAction = pattern.actions[completedCount];
+
+      // Check if we already have this suggestion
+      const existing = suggestions.find(s => s.tool === nextAction.tool);
+      if (!existing) {
+        suggestions.push({
+          action: `Use ${nextAction.tool}`,
+          tool: nextAction.tool,
+          confidence: similarity_score * pattern.confidence,
+          based_on_patterns: [pattern.id],
+          reasoning: `Based on similar workflow "${pattern.trigger.substring(0, 30)}..." which used ${nextAction.tool} at this step`
+        });
+      } else {
+        // Boost confidence and add pattern reference
+        existing.confidence = Math.min(1, existing.confidence + similarity_score * 0.2);
+        existing.based_on_patterns.push(pattern.id);
+      }
+    }
+  }
+
+  // Sort by confidence
+  return suggestions.sort((a, b) => b.confidence - a.confidence);
+}
+```
+
+---
+
+## 3. Package.json Update
+
+```json
+{
+  "name": "@lanonasis/mem-intel-sdk",
+  "version": "2.0.0",
+  "description": "AI-powered memory and behavior intelligence SDK for LanOnasis Memory-as-a-Service"
+}
+```
+
+---
+
+## Testing the SDK Changes
+
+```typescript
+import { MemoryIntelligenceClient } from '@lanonasis/mem-intel-sdk';
+
+const client = new MemoryIntelligenceClient({
+  apiKey: 'lano_xxx',
+  processingMode: 'offline-fallback',
+  enableCache: true
+});
+
+// Test recordBehavior
+const recorded = await client.recordBehavior({
+  userId: 'user-123',
+  trigger: 'fix authentication bug in login flow',
+  context: {
+    directory: '/home/user/project',
+    projectType: 'typescript-api'
+  },
+  actions: [
+    { tool: 'Read', parameters: { file: 'auth.ts' }, outcome: 'success', timestamp: new Date().toISOString() },
+    { tool: 'Edit', parameters: { file: 'auth.ts' }, outcome: 'success', timestamp: new Date().toISOString() },
+    { tool: 'Bash', parameters: { command: 'npm test' }, outcome: 'success', timestamp: new Date().toISOString() }
+  ],
+  finalOutcome: 'success',
+  confidence: 0.85
+});
+
+console.log('Recorded:', recorded.data.id);
+
+// Test recallBehavior
+const recalled = await client.recallBehavior({
+  userId: 'user-123',
+  context: {
+    currentDirectory: '/home/user/other-project',
+    currentTask: 'fix auth bug',
+    projectType: 'typescript-api'
+  },
+  limit: 5
+});
+
+console.log('Recalled patterns:', recalled.data.total_found);
+console.log('From cache:', recalled.fromCache);
+
+// Test suggestBehavior
+const suggestions = await client.suggestBehavior({
+  userId: 'user-123',
+  currentState: {
+    taskDescription: 'fix authentication issue',
+    completedSteps: ['Read auth.ts']
+  },
+  maxSuggestions: 3
+});
+
+console.log('Suggestions:', suggestions.data.suggestions);
+```
+
+---
+
+## Backward Compatibility
+
+All existing v1.x code continues to work unchanged:
+
+```typescript
+// v1.x code - still works in v2.0
+const patterns = await client.analyzePatterns({ userId, timeRangeDays: 30 });
+const related = await client.findRelated({ memoryId, userId });
+const insights = await client.extractInsights({ userId, topic: 'deployment' });
+```
+
+## Next Steps
+
+After implementing SDK changes:
+1. Proceed to [02-mcp-server-upgrade.md](./02-mcp-server-upgrade.md) for MCP tools
+2. Run the test suite to verify backward compatibility
+3. Update the CHANGELOG.md with v2.0.0 release notes

--- a/services/memory-as-a-service/context-patterns/02-mcp-server-upgrade.md
+++ b/services/memory-as-a-service/context-patterns/02-mcp-server-upgrade.md
@@ -1,0 +1,420 @@
+# MCP Server Upgrade Guide: Behavior Tools
+
+## Overview
+
+This guide provides the MCP tool registrations needed for behavior intelligence in `server/mcp-server.ts`.
+
+## Tools to Register
+
+| Tool Name | Purpose | Read-Only |
+|-----------|---------|-----------|
+| `behavior_record` | Store workflow patterns | No |
+| `behavior_recall` | Query patterns for context | Yes |
+| `behavior_suggest` | Suggest next actions | Yes |
+
+---
+
+## Tool Registration Code
+
+Add these tool registrations to the `createMCPServer` function in `server/mcp-server.ts`:
+
+```typescript
+import { z } from 'zod';
+
+// =============================================================================
+// BEHAVIOR INTELLIGENCE TOOLS (v2.0)
+// =============================================================================
+
+/**
+ * Tool: behavior_record
+ * Records a successful workflow pattern for future recall
+ */
+server.registerTool(
+  'behavior_record',
+  {
+    title: 'Record Behavior Pattern',
+    description: 'Record a successful workflow pattern for future recall and learning. Use this after completing a task successfully to help the system learn from the experience.',
+    inputSchema: z.object({
+      user_id: z.string().uuid().describe('User ID'),
+      trigger: z.string().min(10).max(500).describe('What initiated this workflow (the task or prompt)'),
+      context: z.object({
+        directory: z.string().describe('Working directory'),
+        project_type: z.string().optional().describe('Project type (e.g., typescript-api)'),
+        branch: z.string().optional().describe('Git branch name'),
+        files_touched: z.array(z.string()).optional().describe('Files modified during workflow')
+      }).describe('Execution context'),
+      actions: z.array(z.object({
+        tool: z.string().describe('Tool name used'),
+        parameters: z.record(z.any()).describe('Tool parameters'),
+        outcome: z.enum(['success', 'partial', 'failed']).describe('Action outcome'),
+        timestamp: z.string().datetime().describe('When action occurred'),
+        duration_ms: z.number().optional().describe('Execution time in ms')
+      })).describe('Sequence of actions performed'),
+      final_outcome: z.enum(['success', 'partial', 'failed']).describe('Overall workflow outcome'),
+      confidence: z.number().min(0).max(1).default(0.7).describe('Confidence in this pattern (0.0-1.0)')
+    }).strict(),
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true
+    }
+  },
+  async (rawParams) => {
+    try {
+      const response = await client.recordBehavior({
+        userId: rawParams.user_id,
+        trigger: rawParams.trigger,
+        context: {
+          directory: rawParams.context.directory,
+          projectType: rawParams.context.project_type,
+          branch: rawParams.context.branch,
+          filesTouched: rawParams.context.files_touched
+        },
+        actions: rawParams.actions,
+        finalOutcome: rawParams.final_outcome,
+        confidence: rawParams.confidence
+      });
+
+      const pattern = response.data;
+
+      return {
+        content: [{
+          type: 'text',
+          text: `# Behavior Pattern Recorded
+
+**Pattern ID:** ${pattern.id}
+**Trigger:** ${pattern.trigger.substring(0, 100)}...
+**Actions:** ${pattern.actions.length} steps
+**Confidence:** ${Math.round(pattern.confidence * 100)}%
+**Outcome:** ${pattern.final_outcome}
+
+This pattern will be used to inform future similar tasks.`
+        }]
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [{
+          type: 'text',
+          text: `Error recording behavior: ${error instanceof Error ? error.message : 'Unknown error'}`
+        }]
+      };
+    }
+  }
+);
+
+/**
+ * Tool: behavior_recall
+ * Recalls relevant behavior patterns for the current context
+ */
+server.registerTool(
+  'behavior_recall',
+  {
+    title: 'Recall Behavior Patterns',
+    description: 'Recall relevant behavior patterns for the current task context. Use this at the start of a task to learn from previous similar experiences.',
+    inputSchema: z.object({
+      user_id: z.string().uuid().describe('User ID'),
+      context: z.object({
+        current_directory: z.string().describe('Current working directory'),
+        current_task: z.string().describe('Description of current task'),
+        project_type: z.string().optional().describe('Project type filter')
+      }).describe('Current context'),
+      limit: z.number().int().min(1).max(10).default(5).describe('Maximum patterns to return'),
+      similarity_threshold: z.number().min(0).max(1).default(0.7).describe('Minimum similarity score'),
+      response_format: z.enum(['json', 'markdown']).default('markdown').describe('Output format')
+    }).strict(),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true
+    }
+  },
+  async (rawParams) => {
+    try {
+      const response = await client.recallBehavior({
+        userId: rawParams.user_id,
+        context: {
+          currentDirectory: rawParams.context.current_directory,
+          currentTask: rawParams.context.current_task,
+          projectType: rawParams.context.project_type
+        },
+        limit: rawParams.limit,
+        similarityThreshold: rawParams.similarity_threshold
+      });
+
+      const result = response.data;
+
+      if (rawParams.response_format === 'json') {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(result, null, 2)
+          }]
+        };
+      }
+
+      // Markdown format
+      let md = `# Relevant Behavior Patterns
+
+**Task:** ${rawParams.context.current_task}
+**Found:** ${result.total_found} patterns
+**Source:** ${response.fromCache ? 'Local Cache (fast)' : 'API'}
+
+`;
+
+      if (result.patterns.length === 0) {
+        md += `No matching patterns found. This appears to be a new type of task.`;
+      } else {
+        for (const { pattern, similarity_score, relevance_reason } of result.patterns) {
+          md += `## ${pattern.trigger.substring(0, 60)}...
+
+**Similarity:** ${Math.round(similarity_score * 100)}%
+**Confidence:** ${Math.round(pattern.confidence * 100)}%
+**Used:** ${pattern.use_count} time${pattern.use_count !== 1 ? 's' : ''}
+
+**Action Chain:**
+`;
+          for (const action of pattern.actions) {
+            const icon = action.outcome === 'success' ? '✓' : action.outcome === 'partial' ? '~' : '✗';
+            md += `- ${icon} \`${action.tool}\`\n`;
+          }
+          md += `\n`;
+        }
+      }
+
+      return {
+        content: [{ type: 'text', text: md }]
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [{
+          type: 'text',
+          text: `Error recalling behavior: ${error instanceof Error ? error.message : 'Unknown error'}`
+        }]
+      };
+    }
+  }
+);
+
+/**
+ * Tool: behavior_suggest
+ * Suggests next actions based on learned patterns
+ */
+server.registerTool(
+  'behavior_suggest',
+  {
+    title: 'Suggest Next Actions',
+    description: 'Get AI-powered suggestions for next actions based on learned behavior patterns. Use this when unsure what step to take next.',
+    inputSchema: z.object({
+      user_id: z.string().uuid().describe('User ID'),
+      current_state: z.object({
+        task_description: z.string().describe('What task is being worked on'),
+        completed_steps: z.array(z.string()).describe('Steps already completed'),
+        current_files: z.array(z.string()).optional().describe('Files currently being worked on')
+      }).describe('Current execution state'),
+      max_suggestions: z.number().int().min(1).max(5).default(3).describe('Maximum suggestions'),
+      response_format: z.enum(['json', 'markdown']).default('markdown').describe('Output format')
+    }).strict(),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true
+    }
+  },
+  async (rawParams) => {
+    try {
+      const response = await client.suggestBehavior({
+        userId: rawParams.user_id,
+        currentState: {
+          taskDescription: rawParams.current_state.task_description,
+          completedSteps: rawParams.current_state.completed_steps,
+          currentFiles: rawParams.current_state.current_files
+        },
+        maxSuggestions: rawParams.max_suggestions
+      });
+
+      const result = response.data;
+
+      if (rawParams.response_format === 'json') {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(result, null, 2)
+          }]
+        };
+      }
+
+      // Markdown format
+      let md = `# Suggested Next Actions
+
+**Task:** ${rawParams.current_state.task_description}
+**Completed:** ${rawParams.current_state.completed_steps.length} steps
+
+`;
+
+      if (result.suggestions.length === 0) {
+        md += `No suggestions available. This may be a unique workflow without prior patterns.`;
+      } else {
+        for (let i = 0; i < result.suggestions.length; i++) {
+          const suggestion = result.suggestions[i];
+          md += `## ${i + 1}. ${suggestion.action}
+
+**Tool:** \`${suggestion.tool}\`
+**Confidence:** ${Math.round(suggestion.confidence * 100)}%
+**Reasoning:** ${suggestion.reasoning}
+
+`;
+        }
+      }
+
+      return {
+        content: [{ type: 'text', text: md }]
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [{
+          type: 'text',
+          text: `Error suggesting behavior: ${error instanceof Error ? error.message : 'Unknown error'}`
+        }]
+      };
+    }
+  }
+);
+```
+
+---
+
+## Updated Tool List
+
+After adding these tools, your MCP server exposes:
+
+### Memory Intelligence Tools (v1.x)
+| Tool | Purpose |
+|------|---------|
+| `memory_analyze_patterns` | Analyze usage patterns |
+| `memory_suggest_tags` | AI tag suggestions |
+| `memory_find_related` | Semantic similarity search |
+| `memory_detect_duplicates` | Find duplicate memories |
+| `memory_extract_insights` | Extract insights |
+| `memory_health_check` | Organization health |
+
+### Behavior Intelligence Tools (v2.0)
+| Tool | Purpose |
+|------|---------|
+| `behavior_record` | Store workflow patterns |
+| `behavior_recall` | Query patterns by context |
+| `behavior_suggest` | Suggest next actions |
+
+---
+
+## Tool Usage Examples
+
+### Recording a Pattern (Claude/Agent)
+
+```
+I'll record this successful workflow for future reference.
+
+<tool_call>
+behavior_record({
+  user_id: "550e8400-e29b-41d4-a716-446655440000",
+  trigger: "Fix authentication middleware in Express app",
+  context: {
+    directory: "/home/user/my-api",
+    project_type: "express-api",
+    branch: "fix/auth-middleware"
+  },
+  actions: [
+    {
+      tool: "Read",
+      parameters: { file: "middleware/auth.js" },
+      outcome: "success",
+      timestamp: "2026-01-12T15:00:00Z"
+    },
+    {
+      tool: "Edit",
+      parameters: { file: "middleware/auth.js", changes: "..." },
+      outcome: "success",
+      timestamp: "2026-01-12T15:05:00Z"
+    },
+    {
+      tool: "Bash",
+      parameters: { command: "npm test" },
+      outcome: "success",
+      timestamp: "2026-01-12T15:10:00Z"
+    }
+  ],
+  final_outcome: "success",
+  confidence: 0.9
+})
+</tool_call>
+```
+
+### Recalling Patterns
+
+```
+Let me check for similar past workflows.
+
+<tool_call>
+behavior_recall({
+  user_id: "550e8400-e29b-41d4-a716-446655440000",
+  context: {
+    current_directory: "/home/user/another-api",
+    current_task: "Fix authentication bug",
+    project_type: "express-api"
+  },
+  limit: 3,
+  similarity_threshold: 0.7
+})
+</tool_call>
+```
+
+### Getting Suggestions
+
+```
+What should I do next?
+
+<tool_call>
+behavior_suggest({
+  user_id: "550e8400-e29b-41d4-a716-446655440000",
+  current_state: {
+    task_description: "Fix authentication middleware",
+    completed_steps: ["Read auth.js file"],
+    current_files: ["middleware/auth.js"]
+  },
+  max_suggestions: 3
+})
+</tool_call>
+```
+
+---
+
+## Testing MCP Tools
+
+```bash
+# Test via MCP inspector or direct tool call
+npx @modelcontextprotocol/inspector
+
+# Or programmatically
+node -e "
+const { createMCPServer } = require('./dist/server');
+const server = createMCPServer({ apiKey: 'lano_xxx' });
+
+// List tools
+const tools = server.listTools();
+console.log('Registered tools:', tools.map(t => t.name));
+
+// Should include: behavior_record, behavior_recall, behavior_suggest
+"
+```
+
+---
+
+## Next Steps
+
+1. Proceed to [03-rest-api-upgrade.md](./03-rest-api-upgrade.md) for REST integration
+2. Or skip to [04-database-migration.md](./04-database-migration.md) for database setup

--- a/services/memory-as-a-service/context-patterns/03-rest-api-upgrade.md
+++ b/services/memory-as-a-service/context-patterns/03-rest-api-upgrade.md
@@ -1,0 +1,283 @@
+# REST API Integration Guide
+
+## Overview
+
+The behavior intelligence feature uses **existing REST endpoints** with specific parameters. No new endpoints are required for the MVP.
+
+## Endpoint Mapping
+
+| Behavior Operation | REST Endpoint | Method | Key Parameters |
+|--------------------|---------------|--------|----------------|
+| Record pattern | `/memories` | POST | `type: "workflow"` |
+| Recall patterns | `/memories/search` | POST | `type: "workflow"` |
+| Update use_count | `/memories/{id}` | PUT | `metadata.use_count` |
+| List patterns | `/memories` | GET | `type=workflow` |
+
+---
+
+## 1. Recording Behavior Patterns
+
+### Endpoint
+```
+POST /api/v1/memories
+```
+
+### Request Body
+```json
+{
+  "title": "Workflow: Fix authentication bug in login flow",
+  "content": "{\"trigger\":\"fix auth bug\",\"actions\":[{\"tool\":\"Read\",\"parameters\":{\"file\":\"auth.ts\"},\"outcome\":\"success\",\"timestamp\":\"2026-01-12T15:00:00Z\"},{\"tool\":\"Edit\",\"parameters\":{\"file\":\"auth.ts\"},\"outcome\":\"success\",\"timestamp\":\"2026-01-12T15:05:00Z\"},{\"tool\":\"Bash\",\"parameters\":{\"command\":\"npm test\"},\"outcome\":\"success\",\"timestamp\":\"2026-01-12T15:10:00Z\"}],\"final_outcome\":\"success\",\"duration_ms\":600000}",
+  "type": "workflow",
+  "tags": ["behavior-pattern", "typescript-api", "auth", "bugfix"],
+  "metadata": {
+    "confidence": 0.85,
+    "use_count": 1,
+    "context": {
+      "directory": "/home/user/onasis-gateway",
+      "project_type": "typescript-api",
+      "branch": "main",
+      "files_touched": ["src/auth.ts", "src/auth.test.ts"]
+    }
+  }
+}
+```
+
+### Response
+```json
+{
+  "success": true,
+  "data": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "title": "Workflow: Fix authentication bug in login flow",
+    "content": "...",
+    "type": "workflow",
+    "tags": ["behavior-pattern", "typescript-api", "auth", "bugfix"],
+    "metadata": {
+      "confidence": 0.85,
+      "use_count": 1,
+      "context": { ... }
+    },
+    "created_at": "2026-01-12T15:15:00Z",
+    "updated_at": "2026-01-12T15:15:00Z"
+  }
+}
+```
+
+### cURL Example
+```bash
+curl -X POST "https://api.lanonasis.com/api/v1/memories" \
+  -H "X-API-Key: lano_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Workflow: Fix auth bug",
+    "content": "{\"trigger\":\"fix auth\",\"actions\":[],\"final_outcome\":\"success\"}",
+    "type": "workflow",
+    "tags": ["behavior-pattern"],
+    "metadata": {"confidence": 0.8, "use_count": 1}
+  }'
+```
+
+---
+
+## 2. Recalling Behavior Patterns
+
+### Endpoint
+```
+POST /api/v1/memories/search
+```
+
+### Request Body
+```json
+{
+  "query": "fix authentication bug in typescript",
+  "type": "workflow",
+  "threshold": 0.7,
+  "limit": 5
+}
+```
+
+### Response
+```json
+{
+  "success": true,
+  "data": {
+    "results": [
+      {
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "title": "Workflow: Fix authentication bug in login flow",
+        "content": "...",
+        "type": "workflow",
+        "similarity_score": 0.89,
+        "tags": ["behavior-pattern", "typescript-api"],
+        "metadata": {
+          "confidence": 0.85,
+          "use_count": 3
+        }
+      }
+    ],
+    "total": 1,
+    "query": "fix authentication bug in typescript",
+    "threshold": 0.7
+  }
+}
+```
+
+### cURL Example
+```bash
+curl -X POST "https://api.lanonasis.com/api/v1/memories/search" \
+  -H "X-API-Key: lano_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "fix authentication bug",
+    "type": "workflow",
+    "threshold": 0.7,
+    "limit": 5
+  }'
+```
+
+---
+
+## 3. Updating Pattern Usage
+
+When a pattern is recalled and used, increment `use_count`:
+
+### Endpoint
+```
+PUT /api/v1/memories/{id}
+```
+
+### Request Body
+```json
+{
+  "metadata": {
+    "use_count": 4,
+    "last_used_at": "2026-01-12T16:00:00Z"
+  }
+}
+```
+
+### cURL Example
+```bash
+curl -X PUT "https://api.lanonasis.com/api/v1/memories/550e8400-e29b-41d4-a716-446655440000" \
+  -H "X-API-Key: lano_xxx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "metadata": {
+      "use_count": 4,
+      "last_used_at": "2026-01-12T16:00:00Z"
+    }
+  }'
+```
+
+---
+
+## 4. Listing Workflow Patterns
+
+### Endpoint
+```
+GET /api/v1/memories?type=workflow&sortBy=updated_at&sortOrder=desc
+```
+
+### Query Parameters
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | string | Filter by `workflow` |
+| `tags` | string | Comma-separated tags (e.g., `behavior-pattern,typescript-api`) |
+| `sortBy` | string | Sort field (`created_at`, `updated_at`, `title`) |
+| `sortOrder` | string | `asc` or `desc` |
+| `limit` | number | Max results (default: 20, max: 100) |
+| `offset` | number | Pagination offset |
+
+### cURL Example
+```bash
+curl -X GET "https://api.lanonasis.com/api/v1/memories?type=workflow&limit=10" \
+  -H "X-API-Key: lano_xxx"
+```
+
+---
+
+## Content Schema
+
+The `content` field stores JSON-stringified workflow data:
+
+```typescript
+interface WorkflowContent {
+  trigger: string;           // What initiated this workflow
+  actions: ToolAction[];     // Sequence of tool calls
+  final_outcome: 'success' | 'partial' | 'failed';
+  duration_ms?: number;      // Total duration
+}
+
+interface ToolAction {
+  tool: string;              // Tool name (e.g., "Read", "Edit", "Bash")
+  parameters: object;        // Tool parameters
+  outcome: 'success' | 'partial' | 'failed';
+  timestamp: string;         // ISO timestamp
+  duration_ms?: number;      // Action duration
+}
+```
+
+---
+
+## Metadata Schema
+
+The `metadata` field stores behavior-specific data:
+
+```typescript
+interface BehaviorMetadata {
+  confidence: number;        // 0.0 - 1.0
+  use_count: number;         // Times this pattern was recalled
+  last_used_at?: string;     // ISO timestamp of last recall
+  context: {
+    directory: string;       // Working directory
+    project_type?: string;   // e.g., "typescript-api"
+    branch?: string;         // Git branch
+    files_touched?: string[]; // Modified files
+  };
+}
+```
+
+---
+
+## Future Dedicated Endpoints (Optional)
+
+For a cleaner API surface, consider adding dedicated endpoints:
+
+```yaml
+# Future addition to OpenAPI spec
+
+/behaviors/record:
+  post:
+    summary: Record Behavior Pattern
+    description: Smart recording with deduplication
+
+/behaviors/recall:
+  post:
+    summary: Recall Behavior Patterns
+    description: Context-aware pattern retrieval
+
+/behaviors/suggest:
+  post:
+    summary: Suggest Next Actions
+    description: AI-powered action suggestions
+```
+
+These would wrap the existing `/memories` endpoints with behavior-specific logic.
+
+---
+
+## Error Handling
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| 400 | Invalid request body | Check JSON schema |
+| 401 | Authentication failed | Check API key |
+| 404 | Memory not found | Verify ID exists |
+| 429 | Rate limit exceeded | Implement backoff |
+
+---
+
+## Next Steps
+
+1. Proceed to [04-database-migration.md](./04-database-migration.md) for schema setup
+2. Or [05-edge-functions.md](./05-edge-functions.md) for Supabase edge functions

--- a/services/memory-as-a-service/context-patterns/04-database-migration.md
+++ b/services/memory-as-a-service/context-patterns/04-database-migration.md
@@ -1,0 +1,334 @@
+# Database Migration Guide
+
+## Overview
+
+This migration adds the `behavior_patterns` table for dedicated behavior storage (optional, for v2.1+).
+
+For MVP (v2.0), behavior patterns are stored in the existing `memories` table with `type = 'workflow'`.
+
+---
+
+## Option A: Use Existing Table (MVP - Recommended)
+
+No migration needed. Behavior patterns use the existing `memories` table:
+
+```sql
+-- Existing memories table already supports:
+-- - type: 'workflow' for behavior patterns
+-- - content: JSON string with trigger/actions/outcome
+-- - metadata: JSONB with confidence, use_count, context
+-- - embedding: Vector for semantic search
+
+-- Just ensure the 'workflow' type is indexed
+CREATE INDEX IF NOT EXISTS memories_type_workflow_idx
+  ON public.memories(type)
+  WHERE type = 'workflow';
+
+-- Index for frequent queries
+CREATE INDEX IF NOT EXISTS memories_workflow_confidence_idx
+  ON public.memories((metadata->>'confidence')::float DESC)
+  WHERE type = 'workflow';
+```
+
+---
+
+## Option B: Dedicated Table (v2.1+)
+
+For better performance with large pattern sets, add a dedicated table:
+
+### Migration File
+```sql
+-- Migration: 20260112_add_behavior_patterns.sql
+-- Purpose: Add dedicated table for behavior pattern storage
+
+-- Enable pgvector if not already enabled
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- =============================================================================
+-- BEHAVIOR PATTERNS TABLE
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.behavior_patterns (
+  -- Primary key
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Foreign key to user
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Trigger: what initiated this workflow
+  trigger TEXT NOT NULL,
+  trigger_embedding VECTOR(1536),  -- OpenAI text-embedding-3-small dimension
+
+  -- Context: execution environment
+  context JSONB NOT NULL DEFAULT '{}'::jsonb,
+  -- Expected structure:
+  -- {
+  --   "directory": "/path/to/project",
+  --   "project_type": "typescript-api",
+  --   "branch": "main",
+  --   "files_touched": ["file1.ts", "file2.ts"]
+  -- }
+
+  -- Actions: sequence of tool calls
+  actions JSONB NOT NULL DEFAULT '[]'::jsonb,
+  -- Expected structure:
+  -- [
+  --   {"tool": "Read", "parameters": {...}, "outcome": "success", "timestamp": "...", "duration_ms": 100},
+  --   {"tool": "Edit", "parameters": {...}, "outcome": "success", "timestamp": "...", "duration_ms": 200}
+  -- ]
+
+  -- Outcome
+  final_outcome TEXT NOT NULL CHECK (final_outcome IN ('success', 'partial', 'failed')),
+
+  -- Quality metrics
+  confidence FLOAT NOT NULL DEFAULT 0.7 CHECK (confidence >= 0 AND confidence <= 1),
+  use_count INT NOT NULL DEFAULT 1 CHECK (use_count >= 0),
+  last_used_at TIMESTAMPTZ,
+
+  -- Timestamps
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Add comments
+COMMENT ON TABLE public.behavior_patterns IS 'Stores learned workflow patterns for behavior intelligence';
+COMMENT ON COLUMN public.behavior_patterns.trigger IS 'The task/prompt that initiated this workflow';
+COMMENT ON COLUMN public.behavior_patterns.trigger_embedding IS 'Vector embedding for semantic search';
+COMMENT ON COLUMN public.behavior_patterns.confidence IS 'Quality score (0.0-1.0) based on outcome and user feedback';
+COMMENT ON COLUMN public.behavior_patterns.use_count IS 'Number of times this pattern was recalled and used';
+
+-- =============================================================================
+-- INDEXES
+-- =============================================================================
+
+-- User lookup
+CREATE INDEX behavior_patterns_user_id_idx
+  ON public.behavior_patterns(user_id);
+
+-- Outcome filter
+CREATE INDEX behavior_patterns_final_outcome_idx
+  ON public.behavior_patterns(final_outcome);
+
+-- Confidence ranking
+CREATE INDEX behavior_patterns_confidence_idx
+  ON public.behavior_patterns(confidence DESC);
+
+-- Usage frequency
+CREATE INDEX behavior_patterns_use_count_idx
+  ON public.behavior_patterns(use_count DESC);
+
+-- Vector similarity search (IVFFlat index)
+-- Tune 'lists' based on dataset size:
+--   - Small (<10k): lists = 50
+--   - Medium (10k-100k): lists = 100
+--   - Large (>100k): lists = 200-500
+CREATE INDEX behavior_patterns_embedding_idx
+  ON public.behavior_patterns
+  USING ivfflat (trigger_embedding vector_cosine_ops)
+  WITH (lists = 100);
+
+-- GIN index for JSONB context queries
+CREATE INDEX behavior_patterns_context_idx
+  ON public.behavior_patterns
+  USING GIN (context);
+
+-- GIN index for JSONB actions queries
+CREATE INDEX behavior_patterns_actions_idx
+  ON public.behavior_patterns
+  USING GIN (actions);
+
+-- =============================================================================
+-- ROW LEVEL SECURITY
+-- =============================================================================
+
+ALTER TABLE public.behavior_patterns ENABLE ROW LEVEL SECURITY;
+
+-- Users can only access their own patterns
+CREATE POLICY "Users can view own patterns"
+  ON public.behavior_patterns
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own patterns"
+  ON public.behavior_patterns
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own patterns"
+  ON public.behavior_patterns
+  FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own patterns"
+  ON public.behavior_patterns
+  FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- Service role can access all (for admin/analytics)
+CREATE POLICY "Service role full access"
+  ON public.behavior_patterns
+  FOR ALL
+  TO service_role
+  USING (true);
+
+-- =============================================================================
+-- FUNCTIONS
+-- =============================================================================
+
+-- Auto-update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_behavior_pattern_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER behavior_patterns_updated_at
+  BEFORE UPDATE ON public.behavior_patterns
+  FOR EACH ROW
+  EXECUTE FUNCTION update_behavior_pattern_timestamp();
+
+-- Increment use_count (for recall tracking)
+CREATE OR REPLACE FUNCTION increment_pattern_use_count(pattern_id UUID)
+RETURNS void AS $$
+BEGIN
+  UPDATE public.behavior_patterns
+  SET
+    use_count = use_count + 1,
+    last_used_at = NOW()
+  WHERE id = pattern_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Find similar patterns using vector similarity
+CREATE OR REPLACE FUNCTION find_similar_patterns(
+  query_embedding VECTOR(1536),
+  match_threshold FLOAT DEFAULT 0.7,
+  match_count INT DEFAULT 5,
+  p_user_id UUID DEFAULT NULL
+)
+RETURNS TABLE (
+  id UUID,
+  trigger TEXT,
+  context JSONB,
+  actions JSONB,
+  final_outcome TEXT,
+  confidence FLOAT,
+  use_count INT,
+  similarity FLOAT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    bp.id,
+    bp.trigger,
+    bp.context,
+    bp.actions,
+    bp.final_outcome,
+    bp.confidence,
+    bp.use_count,
+    1 - (bp.trigger_embedding <=> query_embedding) AS similarity
+  FROM public.behavior_patterns bp
+  WHERE
+    (p_user_id IS NULL OR bp.user_id = p_user_id)
+    AND bp.trigger_embedding IS NOT NULL
+    AND 1 - (bp.trigger_embedding <=> query_embedding) >= match_threshold
+  ORDER BY bp.trigger_embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- =============================================================================
+-- GRANTS
+-- =============================================================================
+
+-- Grant usage to authenticated users
+GRANT USAGE ON SCHEMA public TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.behavior_patterns TO authenticated;
+
+-- Grant execute on functions
+GRANT EXECUTE ON FUNCTION increment_pattern_use_count(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION find_similar_patterns(VECTOR(1536), FLOAT, INT, UUID) TO authenticated;
+```
+
+---
+
+## Running the Migration
+
+### Supabase CLI
+```bash
+# Create migration file
+supabase migration new add_behavior_patterns
+
+# Paste the SQL into the generated file
+# Then push to database
+supabase db push
+```
+
+### Direct SQL
+```bash
+# Connect to database and run
+psql $DATABASE_URL -f migrations/20260112_add_behavior_patterns.sql
+```
+
+---
+
+## Verification
+
+```sql
+-- Check table exists
+SELECT EXISTS (
+  SELECT FROM information_schema.tables
+  WHERE table_schema = 'public'
+  AND table_name = 'behavior_patterns'
+);
+
+-- Check indexes
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'behavior_patterns';
+
+-- Check RLS policies
+SELECT policyname, cmd, qual
+FROM pg_policies
+WHERE tablename = 'behavior_patterns';
+
+-- Test insert
+INSERT INTO public.behavior_patterns (user_id, trigger, context, actions, final_outcome)
+VALUES (
+  auth.uid(),
+  'Test workflow trigger',
+  '{"directory": "/test"}',
+  '[{"tool": "Read", "outcome": "success"}]',
+  'success'
+);
+
+-- Test similarity search
+SELECT * FROM find_similar_patterns(
+  '[0.1, 0.2, ...]'::vector(1536),  -- Your embedding
+  0.7,                               -- Threshold
+  5,                                 -- Limit
+  auth.uid()                         -- User filter
+);
+```
+
+---
+
+## Rollback
+
+```sql
+-- Remove everything added by this migration
+DROP FUNCTION IF EXISTS find_similar_patterns CASCADE;
+DROP FUNCTION IF EXISTS increment_pattern_use_count CASCADE;
+DROP TRIGGER IF EXISTS behavior_patterns_updated_at ON public.behavior_patterns;
+DROP FUNCTION IF EXISTS update_behavior_pattern_timestamp CASCADE;
+DROP TABLE IF EXISTS public.behavior_patterns CASCADE;
+```
+
+---
+
+## Next Steps
+
+1. Proceed to [05-edge-functions.md](./05-edge-functions.md) for edge function implementation
+2. Or return to SDK implementation with the schema ready

--- a/services/memory-as-a-service/context-patterns/05-edge-functions.md
+++ b/services/memory-as-a-service/context-patterns/05-edge-functions.md
@@ -1,0 +1,539 @@
+# Edge Functions Guide
+
+## Overview
+
+These Supabase Edge Functions provide the server-side logic for behavior intelligence operations.
+
+---
+
+## Function: `intelligence-behavior-record`
+
+Records a behavior pattern with embedding generation and deduplication.
+
+### File: `supabase/functions/intelligence-behavior-record/index.ts`
+
+```typescript
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-api-key, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+serve(async (req: Request) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    // Validate environment
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    const openaiKey = Deno.env.get('OPENAI_API_KEY');
+    const embeddingModel = Deno.env.get('EMBEDDING_MODEL') || 'text-embedding-3-small';
+
+    if (!supabaseUrl || !supabaseKey) {
+      return new Response(
+        JSON.stringify({ success: false, error: { message: 'Server configuration error', code: 'CONFIG_ERROR' } }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    if (!openaiKey) {
+      return new Response(
+        JSON.stringify({ success: false, error: { message: 'Embedding service not configured', code: 'EMBEDDING_ERROR' } }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Parse request
+    const { user_id, trigger, context, actions, final_outcome, confidence = 0.7 } = await req.json();
+
+    // Validate required fields
+    if (!user_id || !trigger || !actions || !final_outcome) {
+      return new Response(
+        JSON.stringify({ success: false, error: { message: 'Missing required fields', code: 'VALIDATION_ERROR' } }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    // Generate embedding for trigger
+    const embeddingResponse = await fetch('https://api.openai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${openaiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: embeddingModel,
+        input: trigger,
+      }),
+    });
+
+    if (!embeddingResponse.ok) {
+      const errText = await embeddingResponse.text();
+      console.error('Embedding API error:', errText);
+      return new Response(
+        JSON.stringify({ success: false, error: { message: 'Failed to generate embedding', code: 'EMBEDDING_ERROR' } }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const embeddingData = await embeddingResponse.json();
+    const triggerEmbedding = embeddingData.data[0].embedding;
+
+    // Check for near-duplicate using vector similarity
+    const { data: duplicates, error: dupError } = await supabase.rpc('find_similar_patterns', {
+      query_embedding: triggerEmbedding,
+      match_threshold: 0.95,  // High threshold for dedup
+      match_count: 1,
+      p_user_id: user_id,
+    });
+
+    if (dupError) {
+      console.error('Duplicate check error:', dupError);
+      // Continue without dedup check
+    }
+
+    // If duplicate found, update use_count instead of creating new
+    if (duplicates && duplicates.length > 0) {
+      const existingId = duplicates[0].id;
+
+      const { error: updateError } = await supabase.rpc('increment_pattern_use_count', {
+        pattern_id: existingId,
+      });
+
+      if (updateError) {
+        console.error('Update error:', updateError);
+      }
+
+      // Fetch updated pattern
+      const { data: updated } = await supabase
+        .from('behavior_patterns')
+        .select('*')
+        .eq('id', existingId)
+        .single();
+
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: updated,
+          message: 'Updated existing pattern (duplicate detected)',
+        }),
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Insert new pattern
+    const { data, error } = await supabase
+      .from('behavior_patterns')
+      .insert({
+        user_id,
+        trigger,
+        trigger_embedding: triggerEmbedding,
+        context: context || {},
+        actions: actions || [],
+        final_outcome,
+        confidence,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Insert error:', error);
+      return new Response(
+        JSON.stringify({ success: false, error: { message: error.message, code: 'DB_ERROR' } }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, data }),
+      { status: 201, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('Unexpected error:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: { message: 'Internal server error', code: 'INTERNAL_ERROR' } }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});
+```
+
+---
+
+## Function: `intelligence-behavior-recall`
+
+Recalls relevant patterns using vector similarity search.
+
+### File: `supabase/functions/intelligence-behavior-recall/index.ts`
+
+```typescript
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-api-key, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    const openaiKey = Deno.env.get('OPENAI_API_KEY');
+    const embeddingModel = Deno.env.get('EMBEDDING_MODEL') || 'text-embedding-3-small';
+
+    if (!supabaseUrl || !supabaseKey || !openaiKey) {
+      return new Response(
+        JSON.stringify({ success: false, error: { message: 'Server configuration error', code: 'CONFIG_ERROR' } }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { user_id, context, limit = 5, similarity_threshold = 0.7 } = await req.json();
+
+    if (!user_id || !context?.current_task) {
+      return new Response(
+        JSON.stringify({ success: false, error: { message: 'Missing required fields', code: 'VALIDATION_ERROR' } }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    // Generate embedding for current task
+    const embeddingResponse = await fetch('https://api.openai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${openaiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: embeddingModel,
+        input: context.current_task,
+      }),
+    });
+
+    if (!embeddingResponse.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: { message: 'Failed to generate embedding', code: 'EMBEDDING_ERROR' } }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const embeddingData = await embeddingResponse.json();
+    const taskEmbedding = embeddingData.data[0].embedding;
+
+    // Find similar patterns
+    const { data: patterns, error } = await supabase.rpc('find_similar_patterns', {
+      query_embedding: taskEmbedding,
+      match_threshold: similarity_threshold,
+      match_count: limit,
+      p_user_id: user_id,
+    });
+
+    if (error) {
+      console.error('Search error:', error);
+      return new Response(
+        JSON.stringify({ success: false, error: { message: error.message, code: 'DB_ERROR' } }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Increment use_count for recalled patterns
+    for (const pattern of patterns || []) {
+      await supabase.rpc('increment_pattern_use_count', { pattern_id: pattern.id }).catch(() => {});
+    }
+
+    // Format response
+    const result = {
+      patterns: (patterns || []).map((p: any) => ({
+        pattern: {
+          id: p.id,
+          trigger: p.trigger,
+          context: p.context,
+          actions: p.actions,
+          final_outcome: p.final_outcome,
+          confidence: p.confidence,
+          use_count: p.use_count,
+        },
+        similarity_score: p.similarity,
+        relevance_reason: `Matched with ${Math.round(p.similarity * 100)}% similarity`,
+      })),
+      total_found: patterns?.length || 0,
+    };
+
+    return new Response(
+      JSON.stringify({ success: true, data: result }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('Unexpected error:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: { message: 'Internal server error', code: 'INTERNAL_ERROR' } }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});
+```
+
+---
+
+## Function: `intelligence-behavior-suggest`
+
+Generates action suggestions based on recalled patterns.
+
+### File: `supabase/functions/intelligence-behavior-suggest/index.ts`
+
+```typescript
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-api-key, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    const openaiKey = Deno.env.get('OPENAI_API_KEY');
+    const embeddingModel = Deno.env.get('EMBEDDING_MODEL') || 'text-embedding-3-small';
+
+    if (!supabaseUrl || !supabaseKey || !openaiKey) {
+      return new Response(
+        JSON.stringify({ success: false, error: { message: 'Server configuration error', code: 'CONFIG_ERROR' } }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { user_id, current_state, max_suggestions = 3 } = await req.json();
+
+    if (!user_id || !current_state?.task_description) {
+      return new Response(
+        JSON.stringify({ success: false, error: { message: 'Missing required fields', code: 'VALIDATION_ERROR' } }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    // Generate embedding for task description
+    const embeddingResponse = await fetch('https://api.openai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${openaiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: embeddingModel,
+        input: current_state.task_description,
+      }),
+    });
+
+    if (!embeddingResponse.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: { message: 'Failed to generate embedding', code: 'EMBEDDING_ERROR' } }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const embeddingData = await embeddingResponse.json();
+    const taskEmbedding = embeddingData.data[0].embedding;
+
+    // Find similar patterns (with lower threshold for suggestions)
+    const { data: patterns, error } = await supabase.rpc('find_similar_patterns', {
+      query_embedding: taskEmbedding,
+      match_threshold: 0.6,  // Lower threshold for broader suggestions
+      match_count: 10,
+      p_user_id: user_id,
+    });
+
+    if (error) {
+      console.error('Search error:', error);
+      return new Response(
+        JSON.stringify({ success: false, error: { message: error.message, code: 'DB_ERROR' } }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Analyze patterns to generate suggestions
+    const completedCount = current_state.completed_steps?.length || 0;
+    const suggestions: any[] = [];
+
+    for (const pattern of patterns || []) {
+      const actions = pattern.actions || [];
+
+      // Find the next action after current progress
+      if (actions.length > completedCount) {
+        const nextAction = actions[completedCount];
+
+        // Check if we already have this suggestion
+        const existing = suggestions.find(s => s.tool === nextAction.tool);
+
+        if (!existing) {
+          suggestions.push({
+            action: `Use ${nextAction.tool}`,
+            tool: nextAction.tool,
+            confidence: pattern.similarity * pattern.confidence,
+            based_on_patterns: [pattern.id],
+            reasoning: `Based on similar workflow "${pattern.trigger.substring(0, 30)}..." which used ${nextAction.tool} at this step`,
+          });
+        } else {
+          // Boost confidence and add pattern reference
+          existing.confidence = Math.min(1, existing.confidence + pattern.similarity * 0.2);
+          existing.based_on_patterns.push(pattern.id);
+        }
+      }
+    }
+
+    // Sort by confidence and limit
+    const topSuggestions = suggestions
+      .sort((a, b) => b.confidence - a.confidence)
+      .slice(0, max_suggestions);
+
+    return new Response(
+      JSON.stringify({ success: true, data: { suggestions: topSuggestions } }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('Unexpected error:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: { message: 'Internal server error', code: 'INTERNAL_ERROR' } }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});
+```
+
+---
+
+## Deployment
+
+### Deploy All Functions
+```bash
+# Deploy behavior-record
+supabase functions deploy intelligence-behavior-record
+
+# Deploy behavior-recall
+supabase functions deploy intelligence-behavior-recall
+
+# Deploy behavior-suggest
+supabase functions deploy intelligence-behavior-suggest
+```
+
+### Set Environment Variables
+```bash
+# Required for all functions
+supabase secrets set OPENAI_API_KEY=sk-xxx
+
+# Optional (has default)
+supabase secrets set EMBEDDING_MODEL=text-embedding-3-small
+```
+
+---
+
+## Testing
+
+### Test Record
+```bash
+curl -X POST "https://YOUR_PROJECT.supabase.co/functions/v1/intelligence-behavior-record" \
+  -H "Authorization: Bearer YOUR_ANON_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "YOUR_USER_ID",
+    "trigger": "Fix authentication bug",
+    "context": {"directory": "/project"},
+    "actions": [{"tool": "Read", "outcome": "success"}],
+    "final_outcome": "success"
+  }'
+```
+
+### Test Recall
+```bash
+curl -X POST "https://YOUR_PROJECT.supabase.co/functions/v1/intelligence-behavior-recall" \
+  -H "Authorization: Bearer YOUR_ANON_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "YOUR_USER_ID",
+    "context": {"current_task": "Fix auth bug"},
+    "limit": 5
+  }'
+```
+
+### Test Suggest
+```bash
+curl -X POST "https://YOUR_PROJECT.supabase.co/functions/v1/intelligence-behavior-suggest" \
+  -H "Authorization: Bearer YOUR_ANON_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "YOUR_USER_ID",
+    "current_state": {
+      "task_description": "Fix authentication",
+      "completed_steps": ["Read auth.ts"]
+    }
+  }'
+```
+
+---
+
+## Monitoring
+
+```sql
+-- Check function logs in Supabase dashboard
+-- Or query the logs table if available
+
+-- Monitor pattern creation rate
+SELECT
+  date_trunc('day', created_at) AS day,
+  COUNT(*) AS patterns_created
+FROM behavior_patterns
+GROUP BY day
+ORDER BY day DESC
+LIMIT 7;
+
+-- Monitor recall frequency
+SELECT
+  date_trunc('day', last_used_at) AS day,
+  SUM(use_count) AS total_recalls
+FROM behavior_patterns
+WHERE last_used_at IS NOT NULL
+GROUP BY day
+ORDER BY day DESC
+LIMIT 7;
+```
+
+---
+
+## Implementation Complete
+
+You now have all the pieces for behavior intelligence:
+
+1. **SDK** (`01-sdk-upgrade-guide.md`) - Client-side methods
+2. **MCP Server** (`02-mcp-server-upgrade.md`) - Tool registration
+3. **REST API** (`03-rest-api-upgrade.md`) - Endpoint integration
+4. **Database** (`04-database-migration.md`) - Schema and functions
+5. **Edge Functions** (this file) - Server-side logic
+
+Return to [README.md](./README.md) for the implementation checklist.

--- a/services/memory-as-a-service/context-patterns/README.md
+++ b/services/memory-as-a-service/context-patterns/README.md
@@ -1,0 +1,126 @@
+# Context Patterns: Behavior Intelligence Implementation Guide
+
+> **For AI Agents**: This guide contains step-by-step instructions to upgrade `@lanonasis/mem-intel-sdk` from v1.x to v2.0 with behavior intelligence capabilities.
+
+## What This Adds
+
+The "Golden Flavor" - behavioral pattern learning that:
+- **Records** successful workflows as patterns
+- **Recalls** relevant patterns for new tasks (local-first)
+- **Suggests** next actions based on learned history
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                BEHAVIOR INTELLIGENCE v2.0                       │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  SDK Layer (@lanonasis/mem-intel-sdk)                          │
+│  ├── recordBehavior()     → Store patterns                     │
+│  ├── recallBehavior()     → Query patterns (local-first)       │
+│  └── suggestBehavior()    → AI-powered suggestions             │
+│                                                                 │
+│  MCP Server Layer                                              │
+│  ├── behavior_record      → MCP tool registration              │
+│  ├── behavior_recall      → Context-aware retrieval            │
+│  └── behavior_suggest     → Pattern-based predictions          │
+│                                                                 │
+│  REST API Layer                                                │
+│  ├── POST /memories       → Uses type: "workflow"              │
+│  ├── POST /memories/search → Filter by workflow type           │
+│  └── PUT /memories/{id}   → Update use_count                   │
+│                                                                 │
+│  Database Layer (Supabase)                                     │
+│  └── behavior_patterns    → Vector-indexed storage             │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Implementation Files
+
+| File | Purpose | Priority |
+|------|---------|----------|
+| [01-sdk-upgrade-guide.md](./01-sdk-upgrade-guide.md) | TypeScript SDK changes | High |
+| [02-mcp-server-upgrade.md](./02-mcp-server-upgrade.md) | MCP tool registration | High |
+| [03-rest-api-upgrade.md](./03-rest-api-upgrade.md) | REST endpoint integration | Medium |
+| [04-database-migration.md](./04-database-migration.md) | Supabase schema changes | High |
+| [05-edge-functions.md](./05-edge-functions.md) | Edge function implementation | Medium |
+
+## Quick Start for AI Agents
+
+### Step 1: Run Database Migration
+```bash
+# Apply the behavior_patterns table migration
+supabase migration new add_behavior_patterns
+# Copy content from 04-database-migration.md
+supabase db push
+```
+
+### Step 2: Add SDK Types
+```typescript
+// In core/types.ts - Add the new types from 01-sdk-upgrade-guide.md
+```
+
+### Step 3: Implement Client Methods
+```typescript
+// In core/client.ts - Add recordBehavior, recallBehavior, suggestBehavior
+```
+
+### Step 4: Register MCP Tools
+```typescript
+// In server/mcp-server.ts - Register behavior_record, behavior_recall, behavior_suggest
+```
+
+### Step 5: Bump Version
+```json
+{
+  "name": "@lanonasis/mem-intel-sdk",
+  "version": "2.0.0"
+}
+```
+
+## Key Design Principles
+
+### 1. Local-First
+```typescript
+// ALWAYS try local cache before API
+const client = new MemoryIntelligenceClient({
+  apiKey: 'lano_xxx',
+  processingMode: 'offline-fallback',  // ← Critical
+  enableCache: true
+});
+```
+
+### 2. Backward Compatible
+- All v1.x methods unchanged
+- New behavior methods are additive
+- No breaking changes to existing API
+
+### 3. Existing Endpoint Reuse
+- `POST /memories` with `type: "workflow"` for recording
+- `POST /memories/search` with `type: "workflow"` for recall
+- No new REST endpoints required for MVP
+
+## Testing Checklist
+
+- [ ] recordBehavior stores pattern with correct type
+- [ ] recallBehavior returns semantically similar patterns
+- [ ] suggestBehavior provides relevant next actions
+- [ ] Local cache works offline
+- [ ] Duplicate detection prevents redundant patterns
+- [ ] use_count increments on recall
+- [ ] All v1.x tests still pass
+
+## Related Documents
+
+- **Skills**: `.claude/skills/skill-behavior-memory.md` (runtime guidance)
+- **Design Doc**: `.claude/skills/sdk-behavior-extension-design.md` (full spec)
+- **API Spec**: `lanonasis-mcp-rest-api.yaml` (OpenAPI)
+
+## Version History
+
+| Version | Changes |
+|---------|---------|
+| 2.0.0 | Add behavior intelligence (recordBehavior, recallBehavior, suggestBehavior) |
+| 1.1.0 | Current stable release |


### PR DESCRIPTION
Add 5 Claude Skills templates to serve as guardrails for AI agents working on the onasis-gateway core modules:

- skill-base-client.md: Guards universal API client patterns
- skill-vendor-abstraction.md: Prevents vendor lock-in
- skill-metrics-collector.md: Maintains observability standards
- skill-compliance-manager.md: Enforces security/compliance
- skill-version-manager.md: Protects API compatibility

Each skill includes:
- NEVER do rules (breaking changes, security violations)
- MUST follow patterns (EventEmitter, error handling)
- Code examples for safe modifications
- Testing requirements before changes
- Rollback procedures for emergencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Behavioral intelligence v2.0: record/recall/suggest workflow patterns with local-first caching, server tools, edge function support, and migration options for persistent storage.

* **Documentation**
  * Added comprehensive guardian guides (Base Client, Compliance Manager, Metrics Collector, Vendor Abstraction, Version Manager, Behavior Memory), plus SDK upgrade, REST API, edge functions, MCP server, and database migration guides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->