### PR TITLE
fix(versioning): migration rollback capability + tests

### DIFF
--- a/core/versioning/version-manager.js
+++ b/core/versioning/version-manager.js
@@ -11,6 +11,27 @@ class VersionManager extends EventEmitter {
     this.versionMappings = new Map();
     this.compatibilityMatrix = new Map();
     this.migrationHandlers = new Map();
+    this.rollbackHandlers = new Map();
+  }
+
+  /**
+   * Deep clone migration input so a failed/partial migration can be rolled back
+   * to the exact pre-migration state, even if the handler mutated the input.
+   */
+  _snapshot(data) {
+    if (data === undefined || data === null) return data;
+    if (typeof structuredClone === 'function') {
+      try {
+        return structuredClone(data);
+      } catch {
+        /* fall through to JSON clone for non-structured-cloneable values */
+      }
+    }
+    try {
+      return JSON.parse(JSON.stringify(data));
+    } catch {
+      return data; // unclonable (e.g. functions) — best effort, return as-is
+    }
   }
 
   /**
@@ -147,7 +168,7 @@ class VersionManager extends EventEmitter {
     // Check base URL changes
     if (newConfig.baseUrl !== oldConfig.baseUrl) {
       compatibility.breakingChanges.push({
-        type: 'baseUrl',
+        type: 'baseUrl_changed',
         message: `Base URL changed from ${oldConfig.baseUrl} to ${newConfig.baseUrl}`
       });
     }
@@ -345,15 +366,28 @@ class VersionManager extends EventEmitter {
   }
 
   /**
-   * Register migration handler for version transitions
+   * Register migration handler for version transitions.
+   *
+   * @param {Function} handler          (data) => migratedData
+   * @param {Function} [rollbackHandler] (snapshot, error) => restoredData. Optional;
+   *   when omitted, executeMigration falls back to restoring a deep snapshot of the
+   *   pre-migration input. Either way a rollback path always exists.
    */
-  registerMigrationHandler(serviceId, fromVersion, toVersion, handler) {
+  registerMigrationHandler(serviceId, fromVersion, toVersion, handler, rollbackHandler) {
     const key = `${serviceId}:${fromVersion}->${toVersion}`;
     this.migrationHandlers.set(key, handler);
+    if (typeof rollbackHandler === 'function') {
+      this.rollbackHandlers.set(key, rollbackHandler);
+    }
   }
 
   /**
-   * Execute migration between versions
+   * Execute migration between versions.
+   *
+   * Guardrail: migrations NEVER run without rollback capability. A deep snapshot
+   * of the input is taken before the handler runs; on failure the explicit
+   * rollback handler (if registered) is invoked, otherwise the snapshot is
+   * restored. The original error is always re-thrown so callers still fail loudly.
    */
   async executeMigration(serviceId, fromVersion, toVersion, data) {
     const key = `${serviceId}:${fromVersion}->${toVersion}`;
@@ -363,9 +397,13 @@ class VersionManager extends EventEmitter {
       throw new Error(`No migration handler found for ${key}`);
     }
 
+    // Capture pristine state BEFORE the handler can mutate it.
+    const snapshot = this._snapshot(data);
+    const rollbackHandler = this.rollbackHandlers.get(key);
+
     try {
       const migratedData = await handler(data);
-      
+
       this.emit('migration:completed', {
         serviceId,
         fromVersion,
@@ -375,12 +413,44 @@ class VersionManager extends EventEmitter {
 
       return migratedData;
     } catch (error) {
+      let restoredData = snapshot;
+
+      try {
+        if (typeof rollbackHandler === 'function') {
+          restoredData = await rollbackHandler(snapshot, error);
+        }
+      } catch (rollbackError) {
+        // Rollback failed: surface BOTH failures and do not pretend we recovered.
+        this.emit('migration:rollback_failed', {
+          serviceId,
+          fromVersion,
+          toVersion,
+          error,
+          rollbackError
+        });
+        const composite = new Error(
+          `Migration ${key} failed ("${error.message}") and rollback also failed ("${rollbackError.message}")`
+        );
+        composite.cause = error;
+        composite.rollbackError = rollbackError;
+        throw composite;
+      }
+
       this.emit('migration:failed', {
         serviceId,
         fromVersion,
         toVersion,
-        error
+        error,
+        rolledBack: true,
+        restoredData
       });
+      this.emit('migration:rolled_back', {
+        serviceId,
+        fromVersion,
+        toVersion,
+        restoredData
+      });
+
       throw error;
     }
   }

--- a/docs/version-manager-hardening.md
+++ b/docs/version-manager-hardening.md
@@ -1,0 +1,75 @@
+# Version Manager Hardening + Package Publishing — Session Handoff
+
+**Date:** 2026-05-28
+**Scope:** two repos — `onasis-gateway` (version manager) and `lan-onasis-monorepo` (package publishing).
+**Guardrails applied:** `version-manager` guardian skill (semver / deprecation / migration / breaking-change rules), TDD.
+
+---
+
+## 1. Version Manager hardening — `onasis-gateway/core/versioning/version-manager.js`
+
+Closed three gaps found auditing the file against the Version Manager guardian rules.
+
+### What changed
+| # | Gap (vs guardian rule) | Fix |
+|---|---|---|
+| 1 | `executeMigration` had **no rollback** — violated *"NEVER execute migrations without rollback capability."* | Migrations now snapshot input (deep clone) before running. On failure: invoke the explicit rollback handler if registered, else restore the snapshot; emit `migration:rolled_back`; if rollback itself throws, emit `migration:rollback_failed` and throw a composite error. Original error always re-thrown. |
+| 2 | Base-URL breaking change emitted `type: 'baseUrl'` — mismatched the documented `baseUrl_changed`, so consumers filtering by type silently missed it. | Renamed to `type: 'baseUrl_changed'`. |
+| 3 | No test coverage for a safety-critical module used by `unified_gateway.js` + `api_server.js`. | Added `tests/core/version-manager.test.js` (10 tests). |
+
+### API additions (backward compatible)
+- `registerMigrationHandler(serviceId, from, to, handler, rollbackHandler?)` — new optional 5th arg. Existing 4-arg calls keep working (snapshot-restore is the default rollback).
+- New events: `migration:rolled_back`, `migration:rollback_failed`.
+- `migration:failed` now carries `{ rolledBack: true, restoredData }`.
+- New helper `_snapshot(data)` (structuredClone → JSON fallback → as-is).
+
+### Verification
+```
+npx vitest run tests/core/version-manager.test.js   # 10/10 pass
+npx vitest run tests/core                            # 20/20 pass (no regressions)
+```
+Developed test-first: 4 tests failed RED for the missing rollback + naming, then went GREEN after implementation.
+
+---
+
+## 2. Package publishing pipeline — `lan-onasis-monorepo` (private)
+
+A dual-registry (npm + GitHub Packages) auto-sync pipeline that keeps already-published `@lanonasis/*` packages in step and publishes on version bump.
+
+### Files added (in `lan-onasis-monorepo`)
+- `scripts/publishable-packages.json` — allowlist (name → canonical dir → registries).
+- `scripts/registry-sync-audit.mjs` — read-only audit; fails only on policy violations.
+- `scripts/publish-packages.mjs` — version-diff publisher; `DRY_RUN` defaults true; writes `.published.json`.
+- `.github/workflows/publish-packages.yml` — `audit` job (PR/push) + `publish` job gated by the `npm-publish` GitHub Environment.
+
+### Key constraints encoded
+- **No `--provenance`** — fails from a private repo.
+- **GitHub Packages needs `GH_PACKAGES_TOKEN`** (PAT, `write:packages` on `lanonasis` org); built-in `GITHUB_TOKEN` can't publish `@lanonasis/*` from a `thefixer3x`-owned repo.
+- Security trio (`oauth-client`, `security-sdk`, `privacy-sdk`) publishes from `apps/v-secure/*`; the other three from `packages/*`. `scripts/sync-security-packages.sh` keeps them at par.
+- **Visibility:** GitHub Packages + Releases from the private monorepo are **private**; npm stays public.
+
+### Verified
+- `node scripts/registry-sync-audit.mjs` → clean, flags `@lanonasis/brand-kit` (1.1.0 > npm 1.0.1) as the one to publish; no policy violations.
+- `publish-packages.mjs` → dry-run default + skips in-sync packages.
+
+---
+
+## 3. Follow-ups / TODO (tracked in Hermes Kanban)
+
+### Version manager (onasis-gateway)
+- [ ] Implement deprecation→removal **lifecycle enforcement** (30-day timeline, warning headers Day 1-29, safe-remove gate). Currently `deprecateVersion` flags only; no `removeVersion` exists.
+- [ ] `getLatestVersion` should optionally **exclude deprecated** versions.
+- [ ] Align `compareAuthentication` presence-flip type (`authentication_changed`) with the documented breaking-change taxonomy, or document it as an intentional 4th auth case.
+- [ ] Add a **compatibility-matrix report** test + JSDoc/usage doc for migration handlers (handler + rollback contract).
+
+### Publishing pipeline (lan-onasis-monorepo)
+- [ ] Operator: create the `npm-publish` GitHub **Environment** + protection rules; add `NPM_TOKEN`, `GH_PACKAGES_TOKEN` secrets.
+- [ ] Decide whether GitHub-side artifacts should be **public** → if so, run the GH step from the public `v-secure`/`lanonasis-maas` submodule repos.
+- [ ] Reconcile version drift: `brand-kit` (1.1.0 vs 1.0.1), `auth-gateway` (0.2.0 vs 0.0.1) — confirm intentional before first auto-publish.
+- [ ] First publish must remain **manual** for any brand-new name; allowlist is sync-only by design.
+
+### Documentation TODO (future actions to document)
+- [ ] Add a top-level `docs/RELEASE.md` in `lan-onasis-monorepo` describing the publish flow + required secrets/environment.
+- [ ] Document the `sync-security-packages.sh` bidirectional contract (which side is authoritative when).
+- [ ] Add migration-handler authoring guide (how to register rollback handlers) to the gateway docs.
+- [ ] Cross-link this handoff from each repo's CLAUDE.md / README once reviewed.

--- a/tests/core/version-manager.test.js
+++ b/tests/core/version-manager.test.js
@@ -1,0 +1,117 @@
+const VersionManager = require('../../core/versioning/version-manager');
+
+describe('VersionManager - semver validation', () => {
+  it('rejects an invalid semver on registerVersion', () => {
+    const vm = new VersionManager();
+    expect(() => vm.registerVersion('svc', 'not-semver', {})).toThrow('Invalid version format');
+  });
+
+  it('accepts a valid semver and emits version:registered', () => {
+    const vm = new VersionManager();
+    const events = [];
+    vm.on('version:registered', (e) => events.push(e));
+    const config = { baseUrl: 'https://a', endpoints: [], authentication: { type: 'bearer' } };
+    vm.registerVersion('svc', '1.0.0', config);
+    expect(events).toHaveLength(1);
+    expect(events[0].version).toBe('1.0.0');
+  });
+});
+
+describe('VersionManager - breaking change detection', () => {
+  const oldC = () => ({ baseUrl: 'https://a', endpoints: [], authentication: { type: 'bearer' } });
+
+  it('flags a base URL change as breaking with type "baseUrl_changed"', () => {
+    const vm = new VersionManager();
+    const newC = { baseUrl: 'https://b', endpoints: [], authentication: { type: 'bearer' } };
+    const c = vm.analyzeCompatibility(newC, oldC());
+    expect(c.compatible).toBe(false);
+    expect(c.breakingChanges.some((b) => b.type === 'baseUrl_changed')).toBe(true);
+  });
+
+  it('flags a removed endpoint as breaking and not compatible', () => {
+    const vm = new VersionManager();
+    const oldConfig = { baseUrl: 'https://a', authentication: { type: 'bearer' }, endpoints: [{ id: 'getUser', method: 'GET', path: '/u' }] };
+    const newConfig = { baseUrl: 'https://a', authentication: { type: 'bearer' }, endpoints: [] };
+    const c = vm.analyzeCompatibility(newConfig, oldConfig);
+    expect(c.compatible).toBe(false);
+    expect(c.breakingChanges.some((b) => b.type === 'endpoint_removed')).toBe(true);
+  });
+
+  it('treats an added optional endpoint as compatible', () => {
+    const vm = new VersionManager();
+    const oldConfig = { baseUrl: 'https://a', authentication: { type: 'bearer' }, endpoints: [] };
+    const newConfig = { baseUrl: 'https://a', authentication: { type: 'bearer' }, endpoints: [{ id: 'new', method: 'GET', path: '/n' }] };
+    const c = vm.analyzeCompatibility(newConfig, oldConfig);
+    expect(c.compatible).toBe(true);
+  });
+});
+
+describe('VersionManager - migrations with rollback', () => {
+  it('runs the handler, returns migrated data, and emits migration:completed', async () => {
+    const vm = new VersionManager();
+    vm.registerMigrationHandler('svc', '1.0.0', '2.0.0', (d) => ({ ...d, migrated: true }));
+    const completed = [];
+    vm.on('migration:completed', (e) => completed.push(e));
+    const result = await vm.executeMigration('svc', '1.0.0', '2.0.0', { a: 1 });
+    expect(result).toEqual({ a: 1, migrated: true });
+    expect(completed).toHaveLength(1);
+  });
+
+  it('throws when no migration handler is registered', async () => {
+    const vm = new VersionManager();
+    await expect(vm.executeMigration('svc', '1.0.0', '2.0.0', {})).rejects.toThrow('No migration handler');
+  });
+
+  it('rolls back to the original (pre-mutation) data when the handler throws', async () => {
+    const vm = new VersionManager();
+    // handler mutates the input then throws — rollback must restore the snapshot, not the mutated object
+    vm.registerMigrationHandler('svc', '1.0.0', '2.0.0', (d) => {
+      d.count = 999;
+      throw new Error('boom');
+    });
+    const rolledBack = [];
+    vm.on('migration:rolled_back', (e) => rolledBack.push(e));
+    await expect(vm.executeMigration('svc', '1.0.0', '2.0.0', { count: 1 })).rejects.toThrow('boom');
+    expect(rolledBack).toHaveLength(1);
+    expect(rolledBack[0].restoredData).toEqual({ count: 1 });
+  });
+
+  it('invokes an explicit rollback handler with the snapshot and the error', async () => {
+    const vm = new VersionManager();
+    let captured = null;
+    vm.registerMigrationHandler(
+      'svc',
+      '1.0.0',
+      '2.0.0',
+      () => {
+        throw new Error('fail');
+      },
+      (snapshot, err) => {
+        captured = { snapshot, msg: err.message };
+        return { restored: true };
+      },
+    );
+    await expect(vm.executeMigration('svc', '1.0.0', '2.0.0', { a: 1 })).rejects.toThrow('fail');
+    expect(captured.snapshot).toEqual({ a: 1 });
+    expect(captured.msg).toBe('fail');
+  });
+
+  it('surfaces a composite error and emits migration:rollback_failed when rollback itself throws', async () => {
+    const vm = new VersionManager();
+    vm.registerMigrationHandler(
+      'svc',
+      '1.0.0',
+      '2.0.0',
+      () => {
+        throw new Error('orig');
+      },
+      () => {
+        throw new Error('rollback-broke');
+      },
+    );
+    const failed = [];
+    vm.on('migration:rollback_failed', (e) => failed.push(e));
+    await expect(vm.executeMigration('svc', '1.0.0', '2.0.0', {})).rejects.toThrow(/rollback/i);
+    expect(failed).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What
Closes Version Manager guardian-rule gaps in `core/versioning/version-manager.js`.

- **Migration rollback** — `executeMigration` snapshots input before running; on failure invokes the explicit rollback handler or restores the snapshot, emits `migration:rolled_back`; if rollback itself throws, emits `migration:rollback_failed` and throws a composite error. Original error always re-thrown. (Closes *"NEVER execute migrations without rollback capability"*.)
- **`registerMigrationHandler`** gains an optional `rollbackHandler` 5th arg — **backward compatible** with existing 4-arg callers (`unified_gateway.js`, `api_server.js`).
- **Naming** — breaking-change type `baseUrl` → `baseUrl_changed` to match the documented taxonomy.
- **Tests** — new `tests/core/version-manager.test.js` (10 tests).
- **Docs** — `docs/version-manager-hardening.md` end-to-end handoff.

## Verification
```
npx vitest run tests/core/version-manager.test.js   # 10/10
npx vitest run tests/core                            # 20/20, no regressions
```
Developed test-first (4 RED → GREEN).

## Follow-ups
Tracked in Hermes Kanban epic `t_f43d8156` (deprecation→removal lifecycle, docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic rollback support for migrations with snapshot restoration on failure
  * Enhanced migration error handling with detailed status and event notifications

* **Bug Fixes**
  * Corrected base URL change event descriptor type for compatibility analysis

* **Documentation**
  * Added version manager hardening and publishing pipeline guide

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thefixer3x/onasis-gateway/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->